### PR TITLE
feat!: detailed error reporting for token exchange

### DIFF
--- a/examples/delegated-access/main.go
+++ b/examples/delegated-access/main.go
@@ -51,9 +51,9 @@ func main() {
 		if ac.HasErrors() {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadGateway)
-			resourceErrors, globalError := ac.GetErrors()
+			resources, globalError := ac.GetErrors()
 			json.NewEncoder(w).Encode(map[string]any{
-				"errors":       resourceErrors,
+				"resources":    resources,
 				"global_error": globalError,
 			})
 			return

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,8 +22,10 @@ const (
 
 // ErrorDetail describes an error during token exchange.
 type ErrorDetail struct {
-	Error    string `json:"error"`
-	RawError string `json:"raw_error,omitempty"`
+	Message     string `json:"message"`
+	Code        string `json:"code,omitempty"`
+	Description string `json:"description,omitempty"`
+	RawError    string `json:"raw_error,omitempty"`
 }
 
 // AccessContext holds the results of token exchanges for multiple resources.
@@ -69,10 +72,10 @@ func (ac *AccessContext) SetError(detail ErrorDetail) {
 // Returns ResourceAccessError if the resource has an error or no token.
 func (ac *AccessContext) Access(resource string) (*oauth.TokenResponse, error) {
 	if ac.globalError != nil {
-		return nil, &ResourceAccessError{Message: ac.globalError.Error}
+		return nil, &ResourceAccessError{Message: ac.globalError.Message}
 	}
 	if _, hasErr := ac.resourceErrors[resource]; hasErr {
-		return nil, &ResourceAccessError{Message: ac.resourceErrors[resource].Error}
+		return nil, &ResourceAccessError{Message: ac.resourceErrors[resource].Message}
 	}
 	token, ok := ac.tokens[resource]
 	if !ok {
@@ -122,7 +125,7 @@ func (ac *AccessContext) GetResourceError(resource string) *ErrorDetail {
 }
 
 // GetErrors returns all errors (global + per-resource).
-func (ac *AccessContext) GetErrors() (resourceErrors map[string]ErrorDetail, globalError *ErrorDetail) {
+func (ac *AccessContext) GetErrors() (resources map[string]ErrorDetail, globalError *ErrorDetail) {
 	result := make(map[string]ErrorDetail, len(ac.resourceErrors))
 	for k, v := range ac.resourceErrors {
 		result[k] = v
@@ -232,7 +235,7 @@ func (p *AuthProvider) Grant(resources ...string) func(http.Handler) http.Handle
 			if authInfo == nil || authInfo.Token == "" {
 				ac := NewAccessContext()
 				ac.SetError(ErrorDetail{
-					Error: "No authentication token available. Ensure RequireBearerAuth() middleware runs before Grant().",
+					Message: "No authentication token available. Ensure RequireBearerAuth() middleware runs before Grant().",
 				})
 				ctx := context.WithValue(r.Context(), accessContextKey, ac)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -253,7 +256,7 @@ func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, 
 	client, err := p.getOrCreateClient()
 	if err != nil {
 		ac.SetError(ErrorDetail{
-			Error:    "Failed to initialize OAuth client. Server configuration issue.",
+			Message:  "Failed to initialize OAuth client. Server configuration issue.",
 			RawError: err.Error(),
 		})
 		return ac
@@ -272,7 +275,7 @@ func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, 
 			req, err = p.credential.PrepareTokenExchangeRequest(ctx, subjectToken, resource, opts)
 			if err != nil {
 				ac.SetResourceError(resource, ErrorDetail{
-					Error:    fmt.Sprintf("Token exchange failed for %s: %v", resource, err),
+					Message:  fmt.Sprintf("Token exchange failed for %s", resource),
 					RawError: err.Error(),
 				})
 				continue
@@ -287,10 +290,19 @@ func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, 
 
 		resp, err := client.ExchangeToken(ctx, *req)
 		if err != nil {
-			ac.SetResourceError(resource, ErrorDetail{
-				Error:    fmt.Sprintf("Token exchange failed for %s: %v", resource, err),
-				RawError: err.Error(),
-			})
+			detail := ErrorDetail{
+				Message: fmt.Sprintf("Token exchange failed for %s", resource),
+			}
+			var oauthErr *oauth.OAuthError
+			if errors.As(err, &oauthErr) {
+				detail.Code = oauthErr.ErrorCode
+				if oauthErr.Message != "" {
+					detail.Description = oauthErr.Message
+				}
+			} else {
+				detail.RawError = err.Error()
+			}
+			ac.SetResourceError(resource, detail)
 			continue
 		}
 

--- a/mcp/provider_test.go
+++ b/mcp/provider_test.go
@@ -42,7 +42,7 @@ func TestAccessContext_Status(t *testing.T) {
 	t.Run("partial_error", func(t *testing.T) {
 		ac := NewAccessContext()
 		ac.SetToken("res1", &oauth.TokenResponse{AccessToken: "t1"})
-		ac.SetResourceError("res2", ErrorDetail{Error: "failed"})
+		ac.SetResourceError("res2", ErrorDetail{Message: "failed"})
 		if ac.Status() != StatusPartialError {
 			t.Errorf("status: got %q, want partial_error", ac.Status())
 		}
@@ -50,7 +50,7 @@ func TestAccessContext_Status(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		ac := NewAccessContext()
-		ac.SetError(ErrorDetail{Error: "global failure"})
+		ac.SetError(ErrorDetail{Message: "global failure"})
 		if ac.Status() != StatusError {
 			t.Errorf("status: got %q, want error", ac.Status())
 		}
@@ -59,7 +59,7 @@ func TestAccessContext_Status(t *testing.T) {
 
 func TestAccessContext_AccessWithGlobalError(t *testing.T) {
 	ac := NewAccessContext()
-	ac.SetError(ErrorDetail{Error: "global failure"})
+	ac.SetError(ErrorDetail{Message: "global failure"})
 
 	_, err := ac.Access("https://api.github.com")
 	if err == nil {
@@ -73,7 +73,7 @@ func TestAccessContext_AccessWithGlobalError(t *testing.T) {
 
 func TestAccessContext_AccessWithResourceError(t *testing.T) {
 	ac := NewAccessContext()
-	ac.SetResourceError("https://api.github.com", ErrorDetail{Error: "exchange failed"})
+	ac.SetResourceError("https://api.github.com", ErrorDetail{Message: "exchange failed"})
 
 	_, err := ac.Access("https://api.github.com")
 	if err == nil {
@@ -85,7 +85,7 @@ func TestAccessContext_SuccessfulAndFailedResources(t *testing.T) {
 	ac := NewAccessContext()
 	ac.SetToken("res1", &oauth.TokenResponse{AccessToken: "t1"})
 	ac.SetToken("res2", &oauth.TokenResponse{AccessToken: "t2"})
-	ac.SetResourceError("res3", ErrorDetail{Error: "failed"})
+	ac.SetResourceError("res3", ErrorDetail{Message: "failed"})
 
 	successful := ac.SuccessfulResources()
 	if len(successful) != 2 {
@@ -100,7 +100,7 @@ func TestAccessContext_SuccessfulAndFailedResources(t *testing.T) {
 
 func TestAccessContext_SetTokenClearsError(t *testing.T) {
 	ac := NewAccessContext()
-	ac.SetResourceError("res1", ErrorDetail{Error: "failed"})
+	ac.SetResourceError("res1", ErrorDetail{Message: "failed"})
 	ac.SetToken("res1", &oauth.TokenResponse{AccessToken: "t1"})
 
 	if ac.HasResourceError("res1") {

--- a/oauth/token_exchange.go
+++ b/oauth/token_exchange.go
@@ -119,17 +119,21 @@ func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, req TokenExchan
 
 	if resp.StatusCode != http.StatusOK {
 		var errBody map[string]any
-		_ = json.NewDecoder(resp.Body).Decode(&errBody)
-
-		errDetail := ""
-		if desc, ok := errBody["error_description"].(string); ok {
-			errDetail = desc
-		} else if code, ok := errBody["error"].(string); ok {
-			errDetail = code
-		}
-
-		if errDetail != "" {
-			return nil, fmt.Errorf("token exchange failed (HTTP %d): %s", resp.StatusCode, errDetail)
+		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
+			if errCode, ok := errBody["error"].(string); ok {
+				oauthErr := &OAuthError{
+					ErrorCode: errCode,
+				}
+				if desc, ok := errBody["error_description"].(string); ok {
+					oauthErr.Message = desc
+				} else {
+					oauthErr.Message = errCode
+				}
+				if uri, ok := errBody["error_uri"].(string); ok {
+					oauthErr.ErrorURI = uri
+				}
+				return nil, oauthErr
+			}
 		}
 		return nil, fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
 	}

--- a/oauth/token_exchange_test.go
+++ b/oauth/token_exchange_test.go
@@ -3,8 +3,10 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -135,9 +137,48 @@ func TestTokenExchangeClient_ErrorResponse(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	expected := "token exchange failed (HTTP 400): token expired"
-	if err.Error() != expected {
-		t.Errorf("error: got %q, want %q", err.Error(), expected)
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "invalid_grant" {
+		t.Errorf("error code: got %q, want %q", oauthErr.ErrorCode, "invalid_grant")
+	}
+	if oauthErr.Message != "token expired" {
+		t.Errorf("message: got %q, want %q", oauthErr.Message, "token expired")
+	}
+}
+
+func TestTokenExchangeClient_ErrorResponse_NonJSON(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Internal Server Error"))
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewTokenExchangeClient(tokenServer.URL)
+
+	_, err := client.ExchangeToken(context.Background(), TokenExchangeRequest{
+		SubjectToken: "some-token",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var oauthErr *OAuthError
+	if errors.As(err, &oauthErr) {
+		t.Fatalf("expected generic error, got *OAuthError: %v", err)
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("error should contain HTTP status: got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Token exchange HTTP errors now return `*OAuthError` (with `ErrorCode`, `Message`, `ErrorURI`) instead of `fmt.Errorf`
- `ErrorDetail` struct: `Error` field renamed to `Message`, added `Code` and `Description` fields
- `GetErrors()` named return renamed from `resourceErrors` to `resources`
- `ExchangeTokens` uses `errors.As` to extract structured OAuth error fields, or `RawError` from generic errors
- Added `TestTokenExchangeClient_ErrorResponse_NonJSON` test

Ports error reporting from Python SDK ([keycardai/python-sdk#80](https://github.com/keycardai/python-sdk/pull/80)) to Go.

**BREAKING CHANGE:** `ErrorDetail.Error` → `ErrorDetail.Message` (JSON: `"error"` → `"message"`), new `Code`/`Description` fields

## Test plan
- [x] `go test ./...` — all tests pass
- [ ] Verify JSON serialization of `ErrorDetail` produces `"message"` not `"error"`
- [ ] Verify token exchange 400 with `{"error":"invalid_grant","error_description":"policy denied"}` surfaces structured fields

Refs: AGE-58

🤖 Generated with [Claude Code](https://claude.com/claude-code)