### PR TITLE
feat: add ClientCredentialsClient for autonomous workload access

### DIFF
--- a/oauth/client_credentials.go
+++ b/oauth/client_credentials.go
@@ -1,0 +1,163 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// ClientCredentialsRequest represents an RFC 6749 Section 4.4 client credentials request.
+type ClientCredentialsRequest struct {
+	Resource            string
+	Scope               string
+	ClientAssertion     string
+	ClientAssertionType string
+}
+
+// ClientCredentialsClientOption configures a ClientCredentialsClient.
+type ClientCredentialsClientOption func(*clientCredentialsConfig)
+
+type clientCredentialsConfig struct {
+	clientID     string
+	clientSecret string
+	httpClient   *http.Client
+}
+
+// WithCCBasicAuth sets the client ID and secret for HTTP basic auth.
+func WithCCBasicAuth(clientID, clientSecret string) ClientCredentialsClientOption {
+	return func(cfg *clientCredentialsConfig) {
+		cfg.clientID = clientID
+		cfg.clientSecret = clientSecret
+	}
+}
+
+// WithCCHTTPClient sets the HTTP client for client credentials requests.
+func WithCCHTTPClient(c *http.Client) ClientCredentialsClientOption {
+	return func(cfg *clientCredentialsConfig) {
+		cfg.httpClient = c
+	}
+}
+
+// ClientCredentialsClient performs RFC 6749 Section 4.4 client credentials grants
+// against an OAuth authorization server. It lazily discovers the token endpoint
+// via OAuth metadata.
+type ClientCredentialsClient struct {
+	issuerURL string
+	cfg       clientCredentialsConfig
+
+	once          sync.Once
+	tokenEndpoint string
+	discoverErr   error
+}
+
+// NewClientCredentialsClient creates a new ClientCredentialsClient for the given issuer.
+func NewClientCredentialsClient(issuerURL string, opts ...ClientCredentialsClientOption) *ClientCredentialsClient {
+	cfg := clientCredentialsConfig{
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return &ClientCredentialsClient{
+		issuerURL: issuerURL,
+		cfg:       cfg,
+	}
+}
+
+// TokenEndpoint returns the discovered token endpoint URL.
+// It triggers lazy metadata discovery if not already done.
+func (c *ClientCredentialsClient) TokenEndpoint(ctx context.Context) (string, error) {
+	return c.getTokenEndpoint(ctx)
+}
+
+// RequestToken performs a client credentials grant request.
+func (c *ClientCredentialsClient) RequestToken(ctx context.Context, req ClientCredentialsRequest) (*TokenResponse, error) {
+	tokenEndpoint, err := c.getTokenEndpoint(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	body := serializeClientCredentialsRequest(req)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(body.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating client credentials request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if c.cfg.clientID != "" && c.cfg.clientSecret != "" {
+		httpReq.SetBasicAuth(c.cfg.clientID, c.cfg.clientSecret)
+	}
+
+	resp, err := c.cfg.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("client credentials request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
+			if errCode, ok := errBody["error"].(string); ok {
+				oauthErr := &OAuthError{
+					ErrorCode: errCode,
+				}
+				if desc, ok := errBody["error_description"].(string); ok {
+					oauthErr.Message = desc
+				} else {
+					oauthErr.Message = errCode
+				}
+				if uri, ok := errBody["error_uri"].(string); ok {
+					oauthErr.ErrorURI = uri
+				}
+				return nil, oauthErr
+			}
+		}
+		return nil, fmt.Errorf("client credentials request failed (HTTP %d)", resp.StatusCode)
+	}
+
+	return deserializeTokenResponse(resp)
+}
+
+func (c *ClientCredentialsClient) getTokenEndpoint(ctx context.Context) (string, error) {
+	c.once.Do(func() {
+		metadata, err := FetchAuthorizationServerMetadata(ctx, c.issuerURL,
+			WithDiscoveryHTTPClient(c.cfg.httpClient))
+		if err != nil {
+			c.discoverErr = fmt.Errorf("discovering token endpoint: %w", err)
+			return
+		}
+		if metadata.TokenEndpoint == "" {
+			c.discoverErr = fmt.Errorf("authorization server %q does not advertise a token_endpoint", c.issuerURL)
+			return
+		}
+		c.tokenEndpoint = metadata.TokenEndpoint
+	})
+
+	return c.tokenEndpoint, c.discoverErr
+}
+
+func serializeClientCredentialsRequest(req ClientCredentialsRequest) url.Values {
+	params := url.Values{}
+	params.Set("grant_type", "client_credentials")
+
+	if req.Resource != "" {
+		params.Set("resource", req.Resource)
+	}
+	if req.Scope != "" {
+		params.Set("scope", req.Scope)
+	}
+	if req.ClientAssertion != "" {
+		params.Set("client_assertion", req.ClientAssertion)
+	}
+	if req.ClientAssertionType != "" {
+		params.Set("client_assertion_type", req.ClientAssertionType)
+	}
+
+	return params
+}

--- a/oauth/client_credentials_test.go
+++ b/oauth/client_credentials_test.go
@@ -1,0 +1,298 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClientCredentialsClient_RequestToken(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parsing form: %v", err)
+			}
+			if r.Form.Get("grant_type") != "client_credentials" {
+				t.Errorf("unexpected grant_type: %s", r.Form.Get("grant_type"))
+			}
+			if r.Form.Get("resource") != "urn:secret:my-app/api-key" {
+				t.Errorf("unexpected resource: %s", r.Form.Get("resource"))
+			}
+			if r.Form.Get("subject_token") != "" {
+				t.Errorf("subject_token should not be present, got: %s", r.Form.Get("subject_token"))
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "vault-secret-456",
+				"token_type":   "bearer",
+				"expires_in":   3600,
+			})
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL)
+
+	resp, err := client.RequestToken(context.Background(), ClientCredentialsRequest{
+		Resource: "urn:secret:my-app/api-key",
+	})
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	if resp.AccessToken != "vault-secret-456" {
+		t.Errorf("access_token: got %q", resp.AccessToken)
+	}
+	if resp.TokenType != "bearer" {
+		t.Errorf("token_type: got %q", resp.TokenType)
+	}
+	if resp.ExpiresIn != 3600 {
+		t.Errorf("expires_in: got %d", resp.ExpiresIn)
+	}
+}
+
+func TestClientCredentialsClient_BasicAuth(t *testing.T) {
+	var receivedAuth string
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			receivedAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "token",
+				"token_type":   "bearer",
+			})
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL,
+		WithCCBasicAuth("my-client", "my-secret"),
+	)
+
+	_, err := client.RequestToken(context.Background(), ClientCredentialsRequest{
+		Resource: "urn:secret:test",
+	})
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	if receivedAuth == "" {
+		t.Error("expected Authorization header")
+	}
+	if receivedAuth != "Basic bXktY2xpZW50Om15LXNlY3JldA==" {
+		t.Errorf("unexpected Authorization header: %s", receivedAuth)
+	}
+}
+
+func TestClientCredentialsClient_ClientAssertion(t *testing.T) {
+	var receivedAssertion, receivedAssertionType, receivedGrantType string
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			r.ParseForm()
+			receivedGrantType = r.FormValue("grant_type")
+			receivedAssertion = r.FormValue("client_assertion")
+			receivedAssertionType = r.FormValue("client_assertion_type")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "token",
+				"token_type":   "bearer",
+			})
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL)
+	_, err := client.RequestToken(context.Background(), ClientCredentialsRequest{
+		Resource:            "urn:secret:my-app/slack-token",
+		ClientAssertion:     "fly-oidc-jwt-here",
+		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+	})
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	if receivedGrantType != "client_credentials" {
+		t.Errorf("grant_type: got %q", receivedGrantType)
+	}
+	if receivedAssertion != "fly-oidc-jwt-here" {
+		t.Errorf("client_assertion: got %q", receivedAssertion)
+	}
+	if receivedAssertionType != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("client_assertion_type: got %q", receivedAssertionType)
+	}
+}
+
+func TestClientCredentialsClient_ErrorResponse(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error":             "access_denied",
+				"error_description": "policy denied access",
+			})
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL)
+
+	_, err := client.RequestToken(context.Background(), ClientCredentialsRequest{
+		Resource: "urn:secret:forbidden",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "access_denied" {
+		t.Errorf("error code: got %q, want %q", oauthErr.ErrorCode, "access_denied")
+	}
+	if oauthErr.Message != "policy denied access" {
+		t.Errorf("message: got %q, want %q", oauthErr.Message, "policy denied access")
+	}
+}
+
+func TestClientCredentialsClient_ErrorResponse_NonJSON(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("Internal Server Error"))
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL)
+
+	_, err := client.RequestToken(context.Background(), ClientCredentialsRequest{
+		Resource: "urn:secret:test",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var oauthErr *OAuthError
+	if errors.As(err, &oauthErr) {
+		t.Fatalf("expected generic error, got *OAuthError: %v", err)
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("error should contain HTTP status: got %q", err.Error())
+	}
+}
+
+func TestClientCredentialsClient_TokenEndpoint(t *testing.T) {
+	requestCount := 0
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			requestCount++
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL)
+
+	endpoint, err := client.TokenEndpoint(context.Background())
+	if err != nil {
+		t.Fatalf("TokenEndpoint: %v", err)
+	}
+	expectedEndpoint := tokenServer.URL + "/token"
+	if endpoint != expectedEndpoint {
+		t.Errorf("endpoint: got %q, want %q", endpoint, expectedEndpoint)
+	}
+
+	endpoint2, err := client.TokenEndpoint(context.Background())
+	if err != nil {
+		t.Fatalf("TokenEndpoint (cached): %v", err)
+	}
+	if endpoint2 != expectedEndpoint {
+		t.Errorf("cached endpoint: got %q, want %q", endpoint2, expectedEndpoint)
+	}
+	if requestCount != 1 {
+		t.Errorf("expected 1 discovery request, got %d", requestCount)
+	}
+}
+
+func TestClientCredentialsClient_Scope(t *testing.T) {
+	var receivedScope string
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			r.ParseForm()
+			receivedScope = r.FormValue("scope")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "token",
+				"token_type":   "bearer",
+				"scope":        "read write",
+			})
+		}
+	}))
+	defer tokenServer.Close()
+
+	client := NewClientCredentialsClient(tokenServer.URL)
+	resp, err := client.RequestToken(context.Background(), ClientCredentialsRequest{
+		Scope: "read write",
+	})
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+
+	if receivedScope != "read write" {
+		t.Errorf("scope: got %q, want %q", receivedScope, "read write")
+	}
+	if len(resp.Scope) != 2 || resp.Scope[0] != "read" || resp.Scope[1] != "write" {
+		t.Errorf("response scope: got %v", resp.Scope)
+	}
+}


### PR DESCRIPTION
Add oauth.ClientCredentialsClient alongside TokenExchangeClient to support RFC 6749 Section 4.4 client_credentials grants. This enables workloads to authenticate directly (e.g., via OIDC workload identity) and retrieve Vault-managed credentials without a subject_token.

Follows the same patterns as TokenExchangeClient:
- Lazy metadata discovery via sync.Once
- Functional option configuration
- Shared deserializeTokenResponse for response parsing
- OAuthError for structured error handling

Resolves https://github.com/keycardai/credentials-go/issues/5