### PR TITLE
feat: add FlyWorkloadIdentityCredential for Fly.io OIDC

### DIFF
--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -29,3 +29,12 @@ type EKSWorkloadIdentityConfigurationError struct {
 func (e *EKSWorkloadIdentityConfigurationError) Error() string {
 	return e.Message
 }
+
+// FlyWorkloadIdentityConfigurationError indicates invalid Fly.io workload identity configuration.
+type FlyWorkloadIdentityConfigurationError struct {
+	Message string
+}
+
+func (e *FlyWorkloadIdentityConfigurationError) Error() string {
+	return e.Message
+}

--- a/mcp/fly.go
+++ b/mcp/fly.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+const (
+	defaultFlySocketPath = "/.fly/api"
+	defaultFlyOIDCPath   = "http://localhost/v1/tokens/oidc"
+)
+
+// FlyWorkloadIdentityCredential implements ApplicationCredential using
+// Fly.io OIDC tokens fetched from the local machine API Unix socket.
+type FlyWorkloadIdentityCredential struct {
+	socketPath string
+	audience   string
+}
+
+// FlyWorkloadIdentityOption configures a FlyWorkloadIdentityCredential.
+type FlyWorkloadIdentityOption func(*flyConfig)
+
+type flyConfig struct {
+	socketPath string
+	audience   string
+}
+
+// WithFlySocketPath overrides the default Unix socket path (/.fly/api).
+func WithFlySocketPath(path string) FlyWorkloadIdentityOption {
+	return func(cfg *flyConfig) { cfg.socketPath = path }
+}
+
+// WithFlyAudience sets the audience claim for the OIDC token request.
+// Typically the Keycard zone URL.
+func WithFlyAudience(audience string) FlyWorkloadIdentityOption {
+	return func(cfg *flyConfig) { cfg.audience = audience }
+}
+
+// NewFlyWorkloadIdentity creates a new FlyWorkloadIdentityCredential.
+func NewFlyWorkloadIdentity(opts ...FlyWorkloadIdentityOption) *FlyWorkloadIdentityCredential {
+	cfg := flyConfig{
+		socketPath: defaultFlySocketPath,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return &FlyWorkloadIdentityCredential{
+		socketPath: cfg.socketPath,
+		audience:   cfg.audience,
+	}
+}
+
+// Auth returns nil (Fly uses assertion-based auth, not basic auth).
+func (f *FlyWorkloadIdentityCredential) Auth() *ClientAuth {
+	return nil
+}
+
+// PrepareTokenExchangeRequest builds a token exchange request with the
+// Fly OIDC token as the client assertion.
+func (f *FlyWorkloadIdentityCredential) PrepareTokenExchangeRequest(ctx context.Context, subjectToken, resource string, _ *PrepareOptions) (*oauth.TokenExchangeRequest, error) {
+	flyToken, err := f.fetchOIDCToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oauth.TokenExchangeRequest{
+		SubjectToken:        subjectToken,
+		Resource:            resource,
+		SubjectTokenType:    "urn:ietf:params:oauth:token-type:access_token",
+		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+		ClientAssertion:     flyToken,
+	}, nil
+}
+
+// fetchOIDCToken requests a short-lived OIDC JWT from the Fly.io machine API
+// via the local Unix socket.
+func (f *FlyWorkloadIdentityCredential) fetchOIDCToken(ctx context.Context) (string, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", f.socketPath)
+			},
+		},
+	}
+
+	var body string
+	if f.audience != "" {
+		body = fmt.Sprintf(`{"aud":"%s"}`, f.audience)
+	} else {
+		body = `{}`
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", defaultFlyOIDCPath, strings.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("creating Fly OIDC request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", &FlyWorkloadIdentityConfigurationError{
+			Message: fmt.Sprintf("calling Fly OIDC endpoint at %s: %v (is this running on a Fly Machine?)", f.socketPath, err),
+		}
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading Fly OIDC response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Fly OIDC returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", fmt.Errorf("Fly OIDC returned empty token")
+	}
+
+	return token, nil
+}

--- a/mcp/fly_test.go
+++ b/mcp/fly_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFlyWorkloadIdentity_PrepareTokenExchangeRequest(t *testing.T) {
+	socketPath, cleanup := startFakeOIDCServer(t, "fly-oidc-token-123")
+	defer cleanup()
+
+	cred := NewFlyWorkloadIdentity(
+		WithFlySocketPath(socketPath),
+		WithFlyAudience("https://zone.keycard.cloud"),
+	)
+
+	req, err := cred.PrepareTokenExchangeRequest(context.Background(), "user-token", "urn:secret:test", nil)
+	if err != nil {
+		t.Fatalf("PrepareTokenExchangeRequest: %v", err)
+	}
+
+	if req.ClientAssertion != "fly-oidc-token-123" {
+		t.Errorf("client_assertion: got %q, want %q", req.ClientAssertion, "fly-oidc-token-123")
+	}
+	if req.ClientAssertionType != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("client_assertion_type: got %q", req.ClientAssertionType)
+	}
+	if req.SubjectToken != "user-token" {
+		t.Errorf("subject_token: got %q, want %q", req.SubjectToken, "user-token")
+	}
+	if req.Resource != "urn:secret:test" {
+		t.Errorf("resource: got %q", req.Resource)
+	}
+}
+
+func TestFlyWorkloadIdentity_Auth(t *testing.T) {
+	cred := NewFlyWorkloadIdentity()
+	if cred.Auth() != nil {
+		t.Error("Auth() should return nil for assertion-based credential")
+	}
+}
+
+func TestFlyWorkloadIdentity_SocketNotAvailable(t *testing.T) {
+	cred := NewFlyWorkloadIdentity(
+		WithFlySocketPath("/tmp/nonexistent-fly-socket-test"),
+	)
+
+	_, err := cred.PrepareTokenExchangeRequest(context.Background(), "", "urn:secret:test", nil)
+	if err == nil {
+		t.Fatal("expected error when socket is unavailable")
+	}
+
+	var configErr *FlyWorkloadIdentityConfigurationError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected *FlyWorkloadIdentityConfigurationError, got %T: %v", err, err)
+	}
+}
+
+func TestFlyWorkloadIdentity_DefaultSocketPath(t *testing.T) {
+	cred := NewFlyWorkloadIdentity()
+	if cred.socketPath != "/.fly/api" {
+		t.Errorf("default socket path: got %q, want %q", cred.socketPath, "/.fly/api")
+	}
+}
+
+// startFakeOIDCServer starts a Unix socket HTTP server that mimics the
+// Fly.io OIDC token endpoint. Returns the socket path and a cleanup function.
+func startFakeOIDCServer(t *testing.T, tokenToReturn string) (string, func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "fly-oidc-test")
+	if err != nil {
+		t.Fatalf("creating temp dir: %v", err)
+	}
+
+	socketPath := filepath.Join(dir, "api.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatalf("listening on unix socket: %v", err)
+	}
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/v1/tokens/oidc" && r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(tokenToReturn))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}),
+	}
+
+	go server.Serve(listener)
+
+	return socketPath, func() {
+		server.Close()
+		os.RemoveAll(dir)
+	}
+}


### PR DESCRIPTION
Implements ApplicationCredential for Fly.io Machines. Fetches OIDC tokens from the local Unix socket at /.fly/api, following the same pattern as EKSWorkloadIdentityCredential.

Fly.io OIDC tokens contain org, app, machine, and region claims with a 15-minute TTL. The sub claim follows the format `<org>:<app>:<machine>`.

Resolves https://github.com/keycardai/credentials-go/issues/6