### PR TITLE
docs: mark Go SDK as preview (ACC-221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Keycard Go SDK
 
+> **Preview.** This SDK has not reached parity with the Keycard Python
+> SDK. APIs may change between minor versions. The preview label will
+> be removed once feature parity is reached.
+
 Go SDK for [Keycard](https://keycard.cloud) — OAuth 2.0 and MCP authentication.
 
 ## Installation

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,8 @@
 // Package keycardai provides the Keycard Go SDK for OAuth 2.0 and MCP authentication.
 //
+// Preview: this SDK has not reached parity with the Keycard Python SDK.
+// APIs may change between minor versions until 1.0.
+//
 // The SDK is organized into two sub-packages:
 //
 //   - [github.com/keycardai/credentials-go/oauth] — Pure OAuth 2.0 primitives: JWT signing/verification,


### PR DESCRIPTION
## Summary

Adds a preview banner to the top-level `README.md` and a `Preview:` line to the package godoc in `doc.go` (visible on pkg.go.dev).

## Why

The Go SDK has not reached parity with the Keycard Python SDK and Larry is the only person on it for the AI Miami timeframe. The preview banner sets customer expectations correctly and lets us make breaking changes between minor versions without surprise. Removed once the feature parity matrix (ACC-216) shows parity.

## Wording

README banner:
```
> **Preview.** This SDK has not reached parity with the Keycard Python
> SDK. APIs may change between minor versions. The preview label will
> be removed once feature parity is reached.
```

godoc (no markdown rendering, hence the shorter form):
```
// Preview: this SDK has not reached parity with the Keycard Python SDK.
// APIs may change between minor versions until 1.0.
```

## Test plan

- [x] `go build ./...` succeeds
- [ ] visual check of README on the PR preview before merging
- [ ] visual check of pkg.go.dev rendering after the next tag