### PR TITLE
Update LICENSE to handbook canonical text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,9 @@
-MIT License
+MIT LICENSE
 
-Copyright (c) 2026 Keycard AI, Inc.
+Copyright © 2026 Keycard Labs, inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Why

The engineering handbook ([ways-of-working/public-repositories.md](https://github.com/keycardlabs/engineering-handbook/blob/main/handbook/ways-of-working/public-repositories.md#choosing-a-license)) now defines a canonical MIT license template and copyright line for all public Keycard repos.

This repo is already MIT (correct per policy — protocol-facing credential SDK), but the existing `LICENSE` predates the handbook template. Aligning the wording.

No license change — same MIT terms, just aligned wording.

## Change

- `LICENSE`: replaced with the handbook's canonical MIT template (`handbook/ways-of-working/public-repositories.md`, "MIT template" section).
- Copyright holder changed from `Keycard AI, Inc.` to `Keycard Labs, inc.` to match the handbook template. **Please confirm this is the intended legal entity** — the handbook standardizes on `Keycard Labs, inc.`, but this repo currently uses a different entity name. If `Keycard AI, Inc.` is correct here, the handbook should be updated instead.

No code changes.