### PR TITLE
feat(oauth): add ImpersonateClient with substitute-user subject token

### DIFF
--- a/oauth/impersonate.go
+++ b/oauth/impersonate.go
@@ -1,0 +1,126 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// SubstituteUserTokenType is the token type URN for Keycard impersonation subject tokens.
+const SubstituteUserTokenType = "urn:keycard:params:oauth:token-type:substitute-user"
+
+const substituteUserActorTokenType = "urn:ietf:params:oauth:token-type:access_token"
+
+// substituteUserHeader is the fixed JWT header for substitute-user tokens.
+type substituteUserHeader struct {
+	Typ string `json:"typ"`
+	Alg string `json:"alg"`
+}
+
+// substituteUserPayload is the JWT payload for substitute-user tokens.
+type substituteUserPayload struct {
+	Sub string `json:"sub"`
+}
+
+// ImpersonateRequest contains the inputs for an impersonation token exchange.
+type ImpersonateRequest struct {
+	// UserIdentifier is the target user; becomes sub in the issued token.
+	UserIdentifier string
+	// Resource is the target resource URI for the issued token. Optional.
+	Resource string
+	// Scopes are the scopes requested for the issued token. Optional.
+	Scopes []string
+}
+
+// ImpersonateClientOption configures an ImpersonateClient.
+type ImpersonateClientOption func(*impersonateConfig)
+
+type impersonateConfig struct {
+	clientID     string
+	clientSecret string
+	httpClient   *http.Client
+}
+
+// WithImpersonateCredentials sets the client ID and secret for authenticating
+// to the token endpoint.
+func WithImpersonateCredentials(clientID, clientSecret string) ImpersonateClientOption {
+	return func(cfg *impersonateConfig) {
+		cfg.clientID = clientID
+		cfg.clientSecret = clientSecret
+	}
+}
+
+// WithImpersonateHTTPClient sets the HTTP client for all token requests.
+func WithImpersonateHTTPClient(c *http.Client) ImpersonateClientOption {
+	return func(cfg *impersonateConfig) {
+		cfg.httpClient = c
+	}
+}
+
+// ImpersonateClient performs Keycard impersonation token exchanges.
+//
+// It handles building the substitute-user subject token and obtaining the actor
+// token from the configured application credential, so callers only need to
+// supply the target user identifier, resource, and scopes.
+type ImpersonateClient struct {
+	cc *ClientCredentialsClient
+	te *TokenExchangeClient
+}
+
+// NewImpersonateClient creates an ImpersonateClient for the given issuer.
+func NewImpersonateClient(issuerURL string, opts ...ImpersonateClientOption) *ImpersonateClient {
+	cfg := impersonateConfig{
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	ccOpts := []ClientCredentialsClientOption{
+		WithCCHTTPClient(cfg.httpClient),
+	}
+	teOpts := []TokenExchangeClientOption{
+		WithTokenExchangeHTTPClient(cfg.httpClient),
+	}
+	if cfg.clientID != "" {
+		ccOpts = append(ccOpts, WithCCBasicAuth(cfg.clientID, cfg.clientSecret))
+		teOpts = append(teOpts, WithClientCredentials(cfg.clientID, cfg.clientSecret))
+	}
+
+	return &ImpersonateClient{
+		cc: NewClientCredentialsClient(issuerURL, ccOpts...),
+		te: NewTokenExchangeClient(issuerURL, teOpts...),
+	}
+}
+
+// Impersonate exchanges the configured application credential for a token that
+// acts on behalf of req.UserIdentifier. The actor identity comes from the
+// credential configured at construction; callers do not pass it explicitly.
+func (c *ImpersonateClient) Impersonate(ctx context.Context, req ImpersonateRequest) (*TokenResponse, error) {
+	actorResp, err := c.cc.RequestToken(ctx, ClientCredentialsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return c.te.ExchangeToken(ctx, TokenExchangeRequest{
+		SubjectToken:     buildSubstituteUserToken(req.UserIdentifier),
+		SubjectTokenType: SubstituteUserTokenType,
+		ActorToken:       actorResp.AccessToken,
+		ActorTokenType:   substituteUserActorTokenType,
+		Resource:         req.Resource,
+		Scope:            strings.Join(req.Scopes, " "),
+	})
+}
+
+// buildSubstituteUserToken constructs the unsigned JWT used as subject_token in
+// Keycard impersonation exchanges. Format per the spec:
+//
+//	base64url({"typ":"vnd.kc.su+jwt","alg":"none"}).base64url({"sub":id}).
+//
+// The trailing dot is intentional — it marks the absent signature segment.
+func buildSubstituteUserToken(userIdentifier string) string {
+	header, _ := json.Marshal(substituteUserHeader{Typ: "vnd.kc.su+jwt", Alg: "none"})
+	payload, _ := json.Marshal(substituteUserPayload{Sub: userIdentifier})
+	return Base64URLEncode(header) + "." + Base64URLEncode(payload) + "."
+}

--- a/oauth/impersonate_test.go
+++ b/oauth/impersonate_test.go
@@ -1,0 +1,264 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuildSubstituteUserToken(t *testing.T) {
+	token := buildSubstituteUserToken("user-42")
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 dot-separated parts, got %d: %q", len(parts), token)
+	}
+	if parts[2] != "" {
+		t.Errorf("signature part must be empty (trailing dot), got %q", parts[2])
+	}
+
+	headerBytes, err := Base64URLDecode(parts[0])
+	if err != nil {
+		t.Fatalf("decoding header: %v", err)
+	}
+	var header map[string]string
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		t.Fatalf("unmarshaling header: %v", err)
+	}
+	if header["typ"] != "vnd.kc.su+jwt" {
+		t.Errorf("header typ: got %q, want %q", header["typ"], "vnd.kc.su+jwt")
+	}
+	if header["alg"] != "none" {
+		t.Errorf("header alg: got %q, want %q", header["alg"], "none")
+	}
+
+	payloadBytes, err := Base64URLDecode(parts[1])
+	if err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		t.Fatalf("unmarshaling payload: %v", err)
+	}
+	if payload["sub"] != "user-42" {
+		t.Errorf("payload sub: got %q, want %q", payload["sub"], "user-42")
+	}
+}
+
+func TestBuildSubstituteUserToken_Deterministic(t *testing.T) {
+	a := buildSubstituteUserToken("alice")
+	b := buildSubstituteUserToken("alice")
+	if a != b {
+		t.Errorf("expected deterministic output, got %q and %q", a, b)
+	}
+}
+
+// mockImpersonateServer returns an httptest.Server that handles:
+//   - /.well-known/oauth-authorization-server  → token endpoint discovery
+//   - /token with grant_type=client_credentials → actor token
+//   - /token with grant_type=token-exchange     → impersonated token (or error)
+func mockImpersonateServer(t *testing.T, exchangeHandler func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parsing form: %v", err)
+			}
+			switch r.Form.Get("grant_type") {
+			case "client_credentials":
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "actor-token-abc",
+					"token_type":   "bearer",
+					"expires_in":   3600,
+				})
+			case "urn:ietf:params:oauth:grant-type:token-exchange":
+				exchangeHandler(w, r)
+			default:
+				t.Errorf("unexpected grant_type: %s", r.Form.Get("grant_type"))
+				http.Error(w, "bad grant_type", http.StatusBadRequest)
+			}
+		}
+	}))
+}
+
+func TestImpersonateClient_Success(t *testing.T) {
+	var capturedSubjectToken, capturedSubjectTokenType, capturedActorToken string
+
+	srv := mockImpersonateServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedSubjectToken = r.Form.Get("subject_token")
+		capturedSubjectTokenType = r.Form.Get("subject_token_type")
+		capturedActorToken = r.Form.Get("actor_token")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "impersonated-token-xyz",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	})
+	defer srv.Close()
+
+	client := NewImpersonateClient(srv.URL, WithImpersonateCredentials("admin-svc", "secret"))
+	resp, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "user-42",
+		Resource:       "https://api.example.com",
+		Scopes:         []string{"read:orders"},
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	if resp.AccessToken != "impersonated-token-xyz" {
+		t.Errorf("access_token: got %q", resp.AccessToken)
+	}
+
+	// Verify subject_token is a valid trailing-dot unsigned JWT with correct sub
+	parts := strings.Split(capturedSubjectToken, ".")
+	if len(parts) != 3 || parts[2] != "" {
+		t.Errorf("subject_token format wrong: %q", capturedSubjectToken)
+	}
+	payloadBytes, _ := Base64URLDecode(parts[1])
+	var payload map[string]string
+	json.Unmarshal(payloadBytes, &payload)
+	if payload["sub"] != "user-42" {
+		t.Errorf("subject_token sub: got %q, want %q", payload["sub"], "user-42")
+	}
+
+	if capturedSubjectTokenType != SubstituteUserTokenType {
+		t.Errorf("subject_token_type: got %q, want %q", capturedSubjectTokenType, SubstituteUserTokenType)
+	}
+	if capturedActorToken != "actor-token-abc" {
+		t.Errorf("actor_token: got %q, want %q", capturedActorToken, "actor-token-abc")
+	}
+}
+
+func TestImpersonateClient_ResourceAndScopes(t *testing.T) {
+	var capturedResource, capturedScope string
+
+	srv := mockImpersonateServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedResource = r.Form.Get("resource")
+		capturedScope = r.Form.Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "token_type": "bearer"})
+	})
+	defer srv.Close()
+
+	client := NewImpersonateClient(srv.URL, WithImpersonateCredentials("svc", "s"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "u1",
+		Resource:       "https://api.example.com",
+		Scopes:         []string{"read:orders", "write:orders"},
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	if capturedResource != "https://api.example.com" {
+		t.Errorf("resource: got %q", capturedResource)
+	}
+	if capturedScope != "read:orders write:orders" {
+		t.Errorf("scope: got %q", capturedScope)
+	}
+}
+
+func TestImpersonateClient_ResourceOmitted(t *testing.T) {
+	var capturedResource string
+
+	srv := mockImpersonateServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedResource = r.Form.Get("resource")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "token_type": "bearer"})
+	})
+	defer srv.Close()
+
+	client := NewImpersonateClient(srv.URL, WithImpersonateCredentials("svc", "s"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "u1",
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	if capturedResource != "" {
+		t.Errorf("expected resource omitted, got %q", capturedResource)
+	}
+}
+
+func TestImpersonateClient_ScopesOmitted(t *testing.T) {
+	var capturedScope string
+
+	srv := mockImpersonateServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedScope = r.Form.Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "token_type": "bearer"})
+	})
+	defer srv.Close()
+
+	client := NewImpersonateClient(srv.URL, WithImpersonateCredentials("svc", "s"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "u1",
+		Resource:       "https://api.example.com",
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	if capturedScope != "" {
+		t.Errorf("expected scope omitted, got %q", capturedScope)
+	}
+}
+
+func TestImpersonateClient_InvalidGrant(t *testing.T) {
+	srv := mockImpersonateServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "user not impersonatable",
+		})
+	})
+	defer srv.Close()
+
+	client := NewImpersonateClient(srv.URL, WithImpersonateCredentials("svc", "s"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{UserIdentifier: "unknown-user"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "invalid_grant" {
+		t.Errorf("error code: got %q, want %q", oauthErr.ErrorCode, "invalid_grant")
+	}
+}
+
+func TestImpersonateClient_UnauthorizedClient(t *testing.T) {
+	srv := mockImpersonateServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "unauthorized_client",
+			"error_description": "client not permitted to impersonate",
+		})
+	})
+	defer srv.Close()
+
+	client := NewImpersonateClient(srv.URL, WithImpersonateCredentials("unprivileged-svc", "s"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{UserIdentifier: "any-user"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "unauthorized_client" {
+		t.Errorf("error code: got %q, want %q", oauthErr.ErrorCode, "unauthorized_client")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the high-level `ImpersonateClient` wrapper in the `oauth` package, closing the gap identified in the spec as Go: partial → full
- Fixes the correctness bug surfaced by [keycardai/keycard-sdk-spec#8](https://github.com/keycardai/keycard-sdk-spec/pull/8): `subject_token` is a client-built unsigned JWT (`typ: vnd.kc.su+jwt`, `alg: none`, `sub: user_identifier`) — not a raw string resolved server-side
- Adds `SubstituteUserTokenType` constant (`urn:keycard:params:oauth:token-type:substitute-user`) so callers don't hard-code the URN

## New API surface (`oauth` package)

```go
// Constant
oauth.SubstituteUserTokenType

// Types
type ImpersonateRequest struct {
    UserIdentifier string
    Resource       string   // optional
    Scopes         []string // optional
}

// Client
client := oauth.NewImpersonateClient(
    issuerURL,
    oauth.WithImpersonateCredentials("admin-svc", "secret"),
)
resp, err := client.Impersonate(ctx, oauth.ImpersonateRequest{
    UserIdentifier: "user-42",
    Resource:       "https://api.example.com",
    Scopes:         []string{"read:orders"},
})
```

The actor identity comes from the client credentials grant using the configured credential; callers do not pass it explicitly.

## Test plan

- [x] `TestBuildSubstituteUserToken` — correct 3-part format, trailing empty signature segment, header/payload decode correctly
- [x] `TestBuildSubstituteUserToken_Deterministic` — same input always produces same output
- [x] `TestImpersonateClient_Success` — correct `subject_token`, `subject_token_type`, and `actor_token` sent on wire
- [x] `TestImpersonateClient_ResourceAndScopes` — both forwarded correctly to exchange request
- [x] `TestImpersonateClient_ResourceOmitted` — exchange succeeds without resource field
- [x] `TestImpersonateClient_ScopesOmitted` — exchange succeeds without scope field
- [x] `TestImpersonateClient_InvalidGrant` — `*OAuthError` with code `invalid_grant`
- [x] `TestImpersonateClient_UnauthorizedClient` — `*OAuthError` with code `unauthorized_client`
- [x] Full `go test ./...` passes (no regressions in `mcp` package)

## Spec reference

keycardai/keycard-sdk-spec#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)