### PR TITLE
feat(oauth): implement user impersonation via substitute-user token exchange (ECO-92)

### DIFF
--- a/examples/impersonation/main.go
+++ b/examples/impersonation/main.go
@@ -1,0 +1,109 @@
+// Package main demonstrates user impersonation via Keycard token exchange.
+//
+// A confidential client (the "background agent") obtains a resource-scoped
+// access token on behalf of a named user, without the user being present.
+// The user must have previously granted access (a delegated grant) for the
+// requested resource. Impersonation is forbidden by default and must be
+// explicitly permitted by server-side Keycard policy.
+//
+// It performs an RFC 8693 token exchange where the actor token is minted from
+// the client's own credentials (a client_credentials grant) and the subject
+// token is an unsigned substitute-user assertion carrying the target user id.
+// The issued token's "sub" is the target user; its "act" chain identifies this
+// service for audit.
+//
+// Configuration (environment variables):
+//
+//	KEYCARD_ZONE_URL       Keycard zone URL for metadata discovery (required)
+//	KEYCARD_CLIENT_ID      Confidential client ID (required)
+//	KEYCARD_CLIENT_SECRET  Confidential client secret (required)
+//	KEYCARD_USER           Target user identifier, becomes "sub" (required)
+//	KEYCARD_RESOURCE       Target resource URI (optional)
+//	KEYCARD_SCOPES         Space-separated scopes (optional)
+//
+// Setup in Keycard Console:
+//
+//	1. Create a provider and a resource (e.g. https://api.github.com).
+//	2. Register this confidential client (password credential) and add the
+//	   resource as a dependency.
+//	3. Ensure the target user has a delegated grant for the resource.
+//	4. Add a policy permitting this application to impersonate.
+//
+// Run:
+//
+//	go run ./examples/impersonation
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+func main() {
+	zoneURL := os.Getenv("KEYCARD_ZONE_URL")
+	clientID := os.Getenv("KEYCARD_CLIENT_ID")
+	clientSecret := os.Getenv("KEYCARD_CLIENT_SECRET")
+	user := os.Getenv("KEYCARD_USER")
+	resource := os.Getenv("KEYCARD_RESOURCE")
+	scopesEnv := strings.TrimSpace(os.Getenv("KEYCARD_SCOPES"))
+
+	if zoneURL == "" || clientID == "" || clientSecret == "" || user == "" {
+		log.Fatal("KEYCARD_ZONE_URL, KEYCARD_CLIENT_ID, KEYCARD_CLIENT_SECRET, and KEYCARD_USER are required")
+	}
+
+	var scopes []string
+	if scopesEnv != "" {
+		scopes = strings.Fields(scopesEnv)
+	}
+
+	fmt.Println("═══ Background Agent (impersonation) ═══")
+	fmt.Println("  Auth:            client_credentials")
+	fmt.Printf("  On behalf of:    %s\n", user)
+	if resource != "" {
+		fmt.Printf("  Access resource: %s\n", resource)
+	}
+	fmt.Println()
+
+	client := oauth.NewTokenExchangeClient(
+		zoneURL,
+		oauth.WithClientCredentials(clientID, clientSecret),
+	)
+
+	token, err := client.Impersonate(context.Background(), oauth.ImpersonateRequest{
+		UserIdentifier: user,
+		Resource:       resource,
+		Scopes:         scopes,
+	})
+	if err != nil {
+		var oauthErr *oauth.OAuthError
+		if errors.As(err, &oauthErr) {
+			// invalid_grant: user unknown or not impersonatable by this client.
+			// unauthorized_client: this client is not permitted to impersonate.
+			log.Fatalf("OAuth error: %s - %s", oauthErr.ErrorCode, oauthErr.Message)
+		}
+		log.Fatalf("impersonation failed: %v", err)
+	}
+
+	fmt.Printf("Access Token: %s...\n", preview(token.AccessToken))
+	fmt.Printf("Token Type:   %s\n", token.TokenType)
+	if token.ExpiresIn > 0 {
+		fmt.Printf("Expires In:   %ds\n", token.ExpiresIn)
+	}
+	if len(token.Scope) > 0 {
+		fmt.Printf("Scope:        %s\n", strings.Join(token.Scope, " "))
+	}
+}
+
+// preview returns a short, non-sensitive prefix of the access token for display.
+func preview(token string) string {
+	if len(token) <= 6 {
+		return token
+	}
+	return token[:6]
+}

--- a/oauth/impersonate.go
+++ b/oauth/impersonate.go
@@ -1,0 +1,135 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SubstituteUserTokenType is the vendor URN used as subject_token_type in
+// Keycard impersonation token exchanges. It signals to the authorization
+// server that the subject_token is an unsigned substitute-user assertion.
+const SubstituteUserTokenType = "urn:keycard:params:oauth:token-type:substitute-user"
+
+// substituteUserActorTokenType is the IANA URN used as actor_token_type when
+// the actor token is an OAuth 2.0 access token (RFC 8693 §3).
+const substituteUserActorTokenType = "urn:ietf:params:oauth:token-type:access_token"
+
+// ImpersonateRequest contains the inputs for an impersonation token exchange.
+//
+// The calling service's application credential supplies the actor identity;
+// callers do not pass it explicitly. The configured TokenExchangeClient
+// credential is used both to mint the actor token (via a client_credentials
+// grant) and to authenticate the exchange request.
+type ImpersonateRequest struct {
+	// UserIdentifier is the target user. Becomes "sub" in the issued token.
+	UserIdentifier string
+	// Resource is the target resource URI for the issued token. Optional.
+	Resource string
+	// Scopes are the scopes requested for the issued token. Optional.
+	Scopes []string
+}
+
+// Impersonate exchanges the client's application credential for a token that
+// acts on behalf of req.UserIdentifier.
+//
+// It performs an RFC 8693 token exchange where:
+//   - actor_token is minted via a client_credentials grant using the
+//     credentials configured on this TokenExchangeClient
+//   - subject_token is an unsigned substitute-user JWT carrying the user id
+//   - subject_token_type is SubstituteUserTokenType
+//
+// Impersonation is a privileged operation gated by server-side policy and is
+// forbidden by default. The authorization server returns "unauthorized_client"
+// when the calling client is not permitted to impersonate.
+func (c *TokenExchangeClient) Impersonate(ctx context.Context, req ImpersonateRequest) (*TokenResponse, error) {
+	if req.UserIdentifier == "" {
+		return nil, errors.New("oauth: ImpersonateRequest.UserIdentifier is required")
+	}
+
+	actor, err := c.grantClientCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.ExchangeToken(ctx, TokenExchangeRequest{
+		SubjectToken:     buildSubstituteUserToken(req.UserIdentifier),
+		SubjectTokenType: SubstituteUserTokenType,
+		ActorToken:       actor.AccessToken,
+		ActorTokenType:   substituteUserActorTokenType,
+		Resource:         req.Resource,
+		Scope:            strings.Join(req.Scopes, " "),
+	})
+}
+
+// grantClientCredentials performs an RFC 6749 §4.4 client_credentials grant
+// against this client's token endpoint, reusing its configured credentials and
+// HTTP client. Returns the access token to be used as actor_token in the
+// subsequent impersonation exchange.
+func (c *TokenExchangeClient) grantClientCredentials(ctx context.Context) (*TokenResponse, error) {
+	tokenEndpoint, err := c.getTokenEndpoint(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	body := url.Values{}
+	body.Set("grant_type", "client_credentials")
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(body.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating client_credentials request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if c.cfg.clientID != "" && c.cfg.clientSecret != "" {
+		httpReq.SetBasicAuth(c.cfg.clientID, c.cfg.clientSecret)
+	}
+
+	resp, err := c.cfg.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("client_credentials request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]any
+		if decErr := json.NewDecoder(resp.Body).Decode(&errBody); decErr == nil {
+			if errCode, ok := errBody["error"].(string); ok {
+				oauthErr := &OAuthError{ErrorCode: errCode}
+				if desc, ok := errBody["error_description"].(string); ok {
+					oauthErr.Message = desc
+				} else {
+					oauthErr.Message = errCode
+				}
+				if uri, ok := errBody["error_uri"].(string); ok {
+					oauthErr.ErrorURI = uri
+				}
+				return nil, oauthErr
+			}
+		}
+		return nil, fmt.Errorf("client_credentials request failed (HTTP %d)", resp.StatusCode)
+	}
+
+	return deserializeTokenResponse(resp)
+}
+
+// buildSubstituteUserToken constructs the unsigned JWT used as subject_token
+// in Keycard impersonation exchanges. The format is:
+//
+//	base64url({"typ":"vnd.kc.su+jwt","alg":"none"}).base64url({"sub":id}).
+//
+// The trailing dot is intentional: it marks the absent signature segment.
+// The token is intentionally unsigned. Authority comes from the client's
+// authentication to the token endpoint plus server-side impersonation policy,
+// not from a signature on this assertion.
+func buildSubstituteUserToken(userIdentifier string) string {
+	header := []byte(`{"typ":"vnd.kc.su+jwt","alg":"none"}`)
+	payload, _ := json.Marshal(struct {
+		Sub string `json:"sub"`
+	}{Sub: userIdentifier})
+	return Base64URLEncode(header) + "." + Base64URLEncode(payload) + "."
+}

--- a/oauth/impersonate.go
+++ b/oauth/impersonate.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 )
 
@@ -26,9 +23,9 @@ const substituteUserActorTokenType = "urn:ietf:params:oauth:token-type:access_to
 // credential is used both to mint the actor token (via a client_credentials
 // grant) and to authenticate the exchange request.
 type ImpersonateRequest struct {
-	// UserIdentifier is the target user. Becomes "sub" in the issued token.
+	// UserIdentifier is the target user. Becomes "sub" in the issued token. Required.
 	UserIdentifier string
-	// Resource is the target resource URI for the issued token. Optional.
+	// Resource is the target resource URI for the issued token. Required.
 	Resource string
 	// Scopes are the scopes requested for the issued token. Optional.
 	Scopes []string
@@ -50,8 +47,11 @@ func (c *TokenExchangeClient) Impersonate(ctx context.Context, req ImpersonateRe
 	if req.UserIdentifier == "" {
 		return nil, errors.New("oauth: ImpersonateRequest.UserIdentifier is required")
 	}
+	if req.Resource == "" {
+		return nil, errors.New("oauth: ImpersonateRequest.Resource is required")
+	}
 
-	actor, err := c.grantClientCredentials(ctx)
+	actor, err := c.clientCredentialsClient().RequestToken(ctx, ClientCredentialsRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -64,57 +64,6 @@ func (c *TokenExchangeClient) Impersonate(ctx context.Context, req ImpersonateRe
 		Resource:         req.Resource,
 		Scope:            strings.Join(req.Scopes, " "),
 	})
-}
-
-// grantClientCredentials performs an RFC 6749 §4.4 client_credentials grant
-// against this client's token endpoint, reusing its configured credentials and
-// HTTP client. Returns the access token to be used as actor_token in the
-// subsequent impersonation exchange.
-func (c *TokenExchangeClient) grantClientCredentials(ctx context.Context) (*TokenResponse, error) {
-	tokenEndpoint, err := c.getTokenEndpoint(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	body := url.Values{}
-	body.Set("grant_type", "client_credentials")
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(body.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("creating client_credentials request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	if c.cfg.clientID != "" && c.cfg.clientSecret != "" {
-		httpReq.SetBasicAuth(c.cfg.clientID, c.cfg.clientSecret)
-	}
-
-	resp, err := c.cfg.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("client_credentials request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		var errBody map[string]any
-		if decErr := json.NewDecoder(resp.Body).Decode(&errBody); decErr == nil {
-			if errCode, ok := errBody["error"].(string); ok {
-				oauthErr := &OAuthError{ErrorCode: errCode}
-				if desc, ok := errBody["error_description"].(string); ok {
-					oauthErr.Message = desc
-				} else {
-					oauthErr.Message = errCode
-				}
-				if uri, ok := errBody["error_uri"].(string); ok {
-					oauthErr.ErrorURI = uri
-				}
-				return nil, oauthErr
-			}
-		}
-		return nil, fmt.Errorf("client_credentials request failed (HTTP %d)", resp.StatusCode)
-	}
-
-	return deserializeTokenResponse(resp)
 }
 
 // buildSubstituteUserToken constructs the unsigned JWT used as subject_token

--- a/oauth/impersonate_test.go
+++ b/oauth/impersonate_test.go
@@ -142,6 +142,7 @@ func TestImpersonate_UnknownUserIdentifier(t *testing.T) {
 	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
 	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
 		UserIdentifier: "ghost@example.com",
+		Resource:       "https://api.example.com",
 	})
 	var oauthErr *OAuthError
 	if !errors.As(err, &oauthErr) {
@@ -159,6 +160,7 @@ func TestImpersonate_UnauthorizedClient(t *testing.T) {
 	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
 	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
 		UserIdentifier: "alice@example.com",
+		Resource:       "https://api.example.com",
 	})
 	var oauthErr *OAuthError
 	if !errors.As(err, &oauthErr) {
@@ -169,20 +171,18 @@ func TestImpersonate_UnauthorizedClient(t *testing.T) {
 	}
 }
 
-// Spec table row 4: resource omitted → exchange call omits resource param.
-func TestImpersonate_ResourceOmitted(t *testing.T) {
-	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
-
-	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+// Spec table row 4: resource omitted → client-side validation error (resource is required).
+func TestImpersonate_ResourceRequiredLocally(t *testing.T) {
+	// No fixture — the request must be rejected before any HTTP call.
+	client := NewTokenExchangeClient("http://unused.invalid")
 	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
 		UserIdentifier: "alice@example.com",
 	})
-	if err != nil {
-		t.Fatalf("Impersonate: %v", err)
+	if err == nil {
+		t.Fatal("expected error for missing Resource")
 	}
-	exchange := f.calls[1]
-	if exchange.Has("resource") {
-		t.Errorf("resource should be omitted, got %q", exchange.Get("resource"))
+	if !strings.Contains(err.Error(), "Resource") {
+		t.Errorf("error should mention Resource, got: %v", err)
 	}
 }
 

--- a/oauth/impersonate_test.go
+++ b/oauth/impersonate_test.go
@@ -1,0 +1,274 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// impersonateFixture stands up a fake authorization server that records the
+// form payload of every /token request so tests can assert on them.
+type impersonateFixture struct {
+	server     *httptest.Server
+	mu         sync.Mutex
+	calls      []url.Values
+	responders []http.HandlerFunc
+}
+
+func newImpersonateFixture(t *testing.T, responders ...http.HandlerFunc) *impersonateFixture {
+	t.Helper()
+	f := &impersonateFixture{responders: responders}
+
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parsing form: %v", err)
+			}
+			f.mu.Lock()
+			idx := len(f.calls)
+			f.calls = append(f.calls, r.Form)
+			f.mu.Unlock()
+
+			if idx >= len(f.responders) {
+				t.Fatalf("unexpected token call #%d", idx+1)
+			}
+			f.responders[idx](w, r)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func ccOKResponder() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "actor-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}
+}
+
+func exchangeOKResponder() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "issued-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"scope":        "read:mail",
+		})
+	}
+}
+
+func oauthErrorResponder(status int, code string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+	}
+}
+
+// Spec table row 1: valid user, valid resource → token returned, substitute-user URN sent.
+func TestImpersonate_FullCall(t *testing.T) {
+	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+
+	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	resp, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "alice@example.com",
+		Resource:       "https://graph.microsoft.com",
+		Scopes:         []string{"read:mail", "read:calendar"},
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	if resp.AccessToken != "issued-token" {
+		t.Errorf("access_token: got %q, want issued-token", resp.AccessToken)
+	}
+
+	if len(f.calls) != 2 {
+		t.Fatalf("token endpoint hit count: got %d, want 2", len(f.calls))
+	}
+
+	cc, exchange := f.calls[0], f.calls[1]
+	if cc.Get("grant_type") != "client_credentials" {
+		t.Errorf("client_credentials grant_type: got %q", cc.Get("grant_type"))
+	}
+
+	if got := exchange.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:token-exchange" {
+		t.Errorf("exchange grant_type: got %q", got)
+	}
+	if got := exchange.Get("subject_token_type"); got != SubstituteUserTokenType {
+		t.Errorf("subject_token_type: got %q, want %q", got, SubstituteUserTokenType)
+	}
+	if got := exchange.Get("actor_token"); got != "actor-access-token" {
+		t.Errorf("actor_token: got %q", got)
+	}
+	if got := exchange.Get("actor_token_type"); got != substituteUserActorTokenType {
+		t.Errorf("actor_token_type: got %q", got)
+	}
+	if got := exchange.Get("resource"); got != "https://graph.microsoft.com" {
+		t.Errorf("resource: got %q", got)
+	}
+	if got := exchange.Get("scope"); got != "read:mail read:calendar" {
+		t.Errorf("scope: got %q", got)
+	}
+
+	payload := decodeSubstituteUserPayload(t, exchange.Get("subject_token"))
+	if payload["sub"] != "alice@example.com" {
+		t.Errorf("subject_token sub: got %v", payload["sub"])
+	}
+}
+
+// Spec table row 2: unknown user_identifier → invalid_grant.
+func TestImpersonate_UnknownUserIdentifier(t *testing.T) {
+	f := newImpersonateFixture(t, ccOKResponder(), oauthErrorResponder(http.StatusBadRequest, "invalid_grant"))
+
+	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "ghost@example.com",
+	})
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "invalid_grant" {
+		t.Errorf("error code: got %q, want invalid_grant", oauthErr.ErrorCode)
+	}
+}
+
+// Spec table row 3: client lacks impersonation permission → unauthorized_client.
+func TestImpersonate_UnauthorizedClient(t *testing.T) {
+	f := newImpersonateFixture(t, ccOKResponder(), oauthErrorResponder(http.StatusBadRequest, "unauthorized_client"))
+
+	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "alice@example.com",
+	})
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "unauthorized_client" {
+		t.Errorf("error code: got %q, want unauthorized_client", oauthErr.ErrorCode)
+	}
+}
+
+// Spec table row 4: resource omitted → exchange call omits resource param.
+func TestImpersonate_ResourceOmitted(t *testing.T) {
+	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+
+	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	exchange := f.calls[1]
+	if exchange.Has("resource") {
+		t.Errorf("resource should be omitted, got %q", exchange.Get("resource"))
+	}
+}
+
+// Spec table row 5: scopes omitted → exchange call omits scope param.
+func TestImpersonate_ScopesOmitted(t *testing.T) {
+	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+
+	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier: "alice@example.com",
+		Resource:       "https://api.example.com",
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	exchange := f.calls[1]
+	if exchange.Has("scope") {
+		t.Errorf("scope should be omitted, got %q", exchange.Get("scope"))
+	}
+}
+
+func TestImpersonate_EmptyUserIdentifierRejectedLocally(t *testing.T) {
+	// No fixture — request must be rejected before any HTTP call.
+	client := NewTokenExchangeClient("http://unused.invalid")
+	_, err := client.Impersonate(context.Background(), ImpersonateRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty UserIdentifier")
+	}
+	if !strings.Contains(err.Error(), "UserIdentifier") {
+		t.Errorf("error should mention UserIdentifier, got: %v", err)
+	}
+}
+
+// buildSubstituteUserToken format checks.
+func TestBuildSubstituteUserToken_Format(t *testing.T) {
+	token := buildSubstituteUserToken("alice@example.com")
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d: %q", len(parts), token)
+	}
+	if parts[2] != "" {
+		t.Errorf("signature segment must be empty, got %q", parts[2])
+	}
+
+	headerBytes, err := Base64URLDecode(parts[0])
+	if err != nil {
+		t.Fatalf("decoding header: %v", err)
+	}
+	var header map[string]string
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		t.Fatalf("parsing header: %v", err)
+	}
+	if header["typ"] != "vnd.kc.su+jwt" {
+		t.Errorf("header.typ: got %q", header["typ"])
+	}
+	if header["alg"] != "none" {
+		t.Errorf("header.alg: got %q", header["alg"])
+	}
+
+	payloadBytes, err := Base64URLDecode(parts[1])
+	if err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		t.Fatalf("parsing payload: %v", err)
+	}
+	if payload["sub"] != "alice@example.com" {
+		t.Errorf("payload.sub: got %q", payload["sub"])
+	}
+}
+
+func decodeSubstituteUserPayload(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d", len(parts))
+	}
+	raw, err := Base64URLDecode(parts[1])
+	if err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parsing payload: %v", err)
+	}
+	return out
+}

--- a/oauth/token_exchange.go
+++ b/oauth/token_exchange.go
@@ -69,6 +69,9 @@ type TokenExchangeClient struct {
 	once          sync.Once
 	tokenEndpoint string
 	discoverErr   error
+
+	ccOnce sync.Once
+	cc     *ClientCredentialsClient
 }
 
 // NewTokenExchangeClient creates a new TokenExchangeClient for the given issuer.
@@ -139,6 +142,20 @@ func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, req TokenExchan
 	}
 
 	return deserializeTokenResponse(resp)
+}
+
+// clientCredentialsClient lazily builds a ClientCredentialsClient that shares this
+// client's issuer, credentials, and HTTP client. It is used to mint the actor token
+// for an impersonation exchange, reusing the client-credentials grant rather than
+// reimplementing it. The instance is cached so it discovers its token endpoint once.
+func (c *TokenExchangeClient) clientCredentialsClient() *ClientCredentialsClient {
+	c.ccOnce.Do(func() {
+		c.cc = NewClientCredentialsClient(c.issuerURL,
+			WithCCBasicAuth(c.cfg.clientID, c.cfg.clientSecret),
+			WithCCHTTPClient(c.cfg.httpClient),
+		)
+	})
+	return c.cc
 }
 
 func (c *TokenExchangeClient) getTokenEndpoint(ctx context.Context) (string, error) {


### PR DESCRIPTION
feat(oauth): implement user impersonation via substitute-user token exchange

Add TokenExchangeClient.Impersonate per
specs/delegated-access/impersonation.md. Mints the actor token from the client's application credential via a client_credentials grant, then performs an RFC 8693 exchange with an unsigned substitute-user subject token carrying the target user identifier.

- ImpersonateRequest: UserIdentifier (req), Resource (opt), Scopes (opt)
- buildSubstituteUserToken + SubstituteUserTokenType vendor URN
- Tests cover the spec unit-test table