### PR TITLE
feat!: enforce RFC 9068 claims and issuer/audience allowlists in JWT verifier (ECO-89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ mux.Handle("/.well-known/", mcp.AuthMetadataHandler(
     mcp.WithScopesSupported([]string{"mcp:tools"}),
 ))
 
+// The verifier trusts only tokens issued by this zone.
+verifier, _ := mcp.NewZoneTokenVerifier("https://your-zone.keycard.cloud")
+
 protected := mcp.RequireBearerAuth(
+    verifier,
     mcp.WithRequiredScopes("mcp:tools"),
 )(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     info := mcp.AuthInfoFromRequest(r)
@@ -69,7 +73,10 @@ authProvider, _ := mcp.NewAuthProvider(
     mcp.WithApplicationCredential(mcp.NewClientSecret(clientID, clientSecret)),
 )
 
+verifier, _ := mcp.NewZoneTokenVerifier("https://your-zone.keycard.cloud")
+
 handler := mcp.RequireBearerAuth(
+    verifier,
     mcp.WithRequiredScopes("mcp:tools"),
 )(authProvider.Grant("https://api.github.com")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     ac := mcp.AccessContextFromRequest(r)

--- a/examples/delegated-access/main.go
+++ b/examples/delegated-access/main.go
@@ -42,8 +42,14 @@ func main() {
 		mcp.WithResourceName("Delegated Access Example"),
 	))
 
+	verifier, err := mcp.NewZoneTokenVerifier(zoneURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Chain: bearer auth -> grant -> handler
 	apiHandler := mcp.RequireBearerAuth(
+		verifier,
 		mcp.WithRequiredScopes("mcp:tools"),
 	)(authProvider.Grant("https://api.github.com")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ac := mcp.AccessContextFromRequest(r)

--- a/examples/hello-world-server/main.go
+++ b/examples/hello-world-server/main.go
@@ -25,8 +25,16 @@ func main() {
 		mcp.WithResourceName("Hello World MCP Server"),
 	))
 
-	// Protected endpoint with bearer auth
+	// The verifier trusts only tokens issued by this zone and resolves keys from its
+	// JWKS. It rejects tokens from any other issuer before resolving a key.
+	verifier, err := mcp.NewZoneTokenVerifier(zoneURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Protected endpoint with bearer auth.
 	protected := mcp.RequireBearerAuth(
+		verifier,
 		mcp.WithRequiredScopes("mcp:tools"),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authInfo := mcp.AuthInfoFromRequest(r)

--- a/mcp/middleware.go
+++ b/mcp/middleware.go
@@ -35,33 +35,30 @@ func AccessContextFromRequest(r *http.Request) *AccessContext {
 type BearerAuthOption func(*bearerAuthConfig)
 
 type bearerAuthConfig struct {
-	verifier       TokenVerifier
 	requiredScopes []string
 }
 
-// WithVerifier sets the token verifier. If not set, a default JWTOAuthTokenVerifier
-// with a JWKSOAuthKeyring is used.
-func WithVerifier(v TokenVerifier) BearerAuthOption {
-	return func(cfg *bearerAuthConfig) { cfg.verifier = v }
-}
-
-// WithRequiredScopes sets the scopes that must be present in the token.
+// WithRequiredScopes sets the scopes that must all be present in the token; a token
+// missing any is rejected with an insufficient-scope failure.
 func WithRequiredScopes(scopes ...string) BearerAuthOption {
 	return func(cfg *bearerAuthConfig) { cfg.requiredScopes = scopes }
 }
 
-// RequireBearerAuth returns middleware that verifies Bearer tokens.
-// On success, stores AuthInfo in the request context (retrieve with AuthInfoFromRequest).
-// On failure, writes the appropriate WWW-Authenticate challenge and HTTP status.
-func RequireBearerAuth(opts ...BearerAuthOption) func(http.Handler) http.Handler {
+// RequireBearerAuth returns middleware that verifies Bearer tokens with verifier.
+// The verifier carries the trusted issuers and audience binding; build one with
+// NewZoneTokenVerifier (single zone) or NewJWTOAuthTokenVerifier (custom keyring or
+// multiple issuers). On success it stores AuthInfo in the request context (read with
+// AuthInfoFromRequest); on failure it writes the appropriate WWW-Authenticate challenge
+// and HTTP status. It panics if verifier is nil, since an auth boundary with no verifier
+// is a programming error best caught at startup.
+func RequireBearerAuth(verifier TokenVerifier, opts ...BearerAuthOption) func(http.Handler) http.Handler {
+	if verifier == nil {
+		panic("mcp: RequireBearerAuth requires a non-nil TokenVerifier")
+	}
+
 	cfg := bearerAuthConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
-	}
-
-	if cfg.verifier == nil {
-		keyring := oauth.NewJWKSOAuthKeyring()
-		cfg.verifier = NewJWTOAuthTokenVerifier(keyring)
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -90,7 +87,7 @@ func RequireBearerAuth(opts ...BearerAuthOption) func(http.Handler) http.Handler
 				return
 			}
 
-			authInfo, err := cfg.verifier.VerifyAccessToken(r.Context(), token)
+			authInfo, err := verifier.VerifyAccessToken(r.Context(), token)
 			if err != nil {
 				var errCode, errMsg string
 

--- a/mcp/middleware_test.go
+++ b/mcp/middleware_test.go
@@ -30,7 +30,7 @@ func TestRequireBearerAuth_ValidToken(t *testing.T) {
 		},
 	}
 
-	handler := RequireBearerAuth(WithVerifier(verifier))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		info := AuthInfoFromRequest(r)
 		json.NewEncoder(w).Encode(info)
 	}))
@@ -49,7 +49,7 @@ func TestRequireBearerAuth_ValidToken(t *testing.T) {
 func TestRequireBearerAuth_MissingHeader(t *testing.T) {
 	verifier := &mockTokenVerifier{}
 
-	handler := RequireBearerAuth(WithVerifier(verifier))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")
 	}))
 
@@ -74,7 +74,7 @@ func TestRequireBearerAuth_MissingHeader(t *testing.T) {
 func TestRequireBearerAuth_MalformedHeader(t *testing.T) {
 	verifier := &mockTokenVerifier{}
 
-	handler := RequireBearerAuth(WithVerifier(verifier))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")
 	}))
 
@@ -96,7 +96,7 @@ func TestRequireBearerAuth_InvalidToken(t *testing.T) {
 		},
 	}
 
-	handler := RequireBearerAuth(WithVerifier(verifier))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")
 	}))
 
@@ -128,7 +128,7 @@ func TestRequireBearerAuth_InsufficientScope(t *testing.T) {
 	}
 
 	handler := RequireBearerAuth(
-		WithVerifier(verifier),
+		verifier,
 		WithRequiredScopes("admin"),
 	)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called")
@@ -162,7 +162,7 @@ func TestRequireBearerAuth_ExpiredToken(t *testing.T) {
 		},
 	}
 
-	handler := RequireBearerAuth(WithVerifier(verifier))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called for expired token")
 	}))
 
@@ -194,7 +194,7 @@ func TestRequireBearerAuth_NoExpiry(t *testing.T) {
 		},
 	}
 
-	handler := RequireBearerAuth(WithVerifier(verifier))(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/mcp/verifier.go
+++ b/mcp/verifier.go
@@ -25,11 +25,26 @@ type JWTOAuthTokenVerifier struct {
 	verifier *oauth.JWTVerifier
 }
 
-// NewJWTOAuthTokenVerifier creates a new JWTOAuthTokenVerifier with the given keyring.
-func NewJWTOAuthTokenVerifier(keyring oauth.OAuthKeyring) *JWTOAuthTokenVerifier {
-	return &JWTOAuthTokenVerifier{
-		verifier: oauth.NewJWTVerifier(keyring),
+// NewJWTOAuthTokenVerifier creates a JWTOAuthTokenVerifier that trusts tokens issued
+// by one of issuers, resolving verification keys through keyring. At least one trusted
+// issuer is required. Additional verifier options (oauth.WithAudiences,
+// oauth.WithAlgorithms, oauth.WithVerifierLeeway) are forwarded to the underlying JWT
+// verifier. Returns a configuration error when no trusted issuer is supplied.
+func NewJWTOAuthTokenVerifier(keyring oauth.OAuthKeyring, issuers []string, opts ...oauth.JWTVerifierOption) (*JWTOAuthTokenVerifier, error) {
+	verifier, err := oauth.NewJWTVerifier(keyring, issuers, opts...)
+	if err != nil {
+		return nil, err
 	}
+	return &JWTOAuthTokenVerifier{verifier: verifier}, nil
+}
+
+// NewZoneTokenVerifier builds a verifier for a single Keycard zone. It trusts only
+// tokens whose iss equals zoneURL and resolves verification keys from that zone's JWKS
+// on demand. Pass oauth.WithAudiences to bind tokens to this resource server. This is
+// the convenience path; use NewJWTOAuthTokenVerifier directly to supply your own keyring
+// or trust more than one issuer.
+func NewZoneTokenVerifier(zoneURL string, opts ...oauth.JWTVerifierOption) (*JWTOAuthTokenVerifier, error) {
+	return NewJWTOAuthTokenVerifier(oauth.NewJWKSOAuthKeyring(), []string{zoneURL}, opts...)
 }
 
 // VerifyAccessToken verifies a JWT access token and returns auth information.

--- a/oauth/errors.go
+++ b/oauth/errors.go
@@ -2,6 +2,16 @@ package oauth
 
 import "fmt"
 
+// ConfigurationError indicates the SDK was constructed with invalid configuration,
+// such as a verifier built without a trusted issuer or with an unsupported algorithm.
+type ConfigurationError struct {
+	Message string
+}
+
+func (e *ConfigurationError) Error() string {
+	return e.Message
+}
+
 // HTTPError represents an HTTP-related error with a status code.
 type HTTPError struct {
 	Message string

--- a/oauth/jwt.go
+++ b/oauth/jwt.go
@@ -217,38 +217,92 @@ func (s *JWTSigner) Sign(ctx context.Context, claims JWTClaims) (string, error) 
 	return signed, nil
 }
 
-// JWTVerifierOption configures a JWTVerifier.
-type JWTVerifierOption func(*JWTVerifier)
+// supportedVerifyAlgorithms is the set of signing algorithms the verifier implements.
+// Construction rejects any configured algorithm outside this set (and "none" always).
+var supportedVerifyAlgorithms = map[string]bool{
+	"RS256": true,
+	"ES256": true,
+}
 
-// WithVerifierLeeway sets the time leeway for validating exp, nbf, and iat claims.
+// jwtVerifierConfig holds the optional verifier settings applied via JWTVerifierOption.
+type jwtVerifierConfig struct {
+	audiences  []string
+	algorithms []string
+	leeway     time.Duration
+}
+
+// JWTVerifierOption configures a JWTVerifier.
+type JWTVerifierOption func(*jwtVerifierConfig)
+
+// WithAudiences sets the accepted audience values. When set, a verified token's aud
+// claim must be present and intersect this set; when unset, audience is not checked.
+func WithAudiences(audiences ...string) JWTVerifierOption {
+	return func(c *jwtVerifierConfig) { c.audiences = audiences }
+}
+
+// WithAlgorithms sets the allowed JWT signing algorithms. Defaults to ["RS256"].
+// "none" is always rejected, and an algorithm the verifier does not implement is a
+// configuration error at construction time.
+func WithAlgorithms(algorithms ...string) JWTVerifierOption {
+	return func(c *jwtVerifierConfig) { c.algorithms = algorithms }
+}
+
+// WithVerifierLeeway sets the time leeway for validating exp and nbf claims.
 // Default is DefaultLeeway (60s).
 func WithVerifierLeeway(d time.Duration) JWTVerifierOption {
-	return func(v *JWTVerifier) { v.leeway = d }
+	return func(c *jwtVerifierConfig) { c.leeway = d }
 }
 
 // JWTVerifier verifies JWT signatures and validates claims using an OAuthKeyring.
+// The verify surface is fail-closed: the algorithm and issuer are checked against
+// allowlists before any key resolution or network I/O, so a token carrying an
+// attacker-controlled iss cannot drive key lookup to an untrusted endpoint.
 type JWTVerifier struct {
-	keyring OAuthKeyring
-	leeway  time.Duration
+	keyring    OAuthKeyring
+	issuers    []string
+	audiences  []string
+	algorithms []string
+	leeway     time.Duration
 }
 
-// NewJWTVerifier creates a new JWTVerifier with the given public keyring.
-func NewJWTVerifier(keyring OAuthKeyring, opts ...JWTVerifierOption) *JWTVerifier {
-	v := &JWTVerifier{keyring: keyring, leeway: DefaultLeeway}
-	for _, opt := range opts {
-		opt(v)
+// NewJWTVerifier creates a JWTVerifier that trusts tokens issued by one of issuers.
+// At least one trusted issuer is required; an empty issuers list, or an unsupported
+// algorithm, is a ConfigurationError.
+func NewJWTVerifier(keyring OAuthKeyring, issuers []string, opts ...JWTVerifierOption) (*JWTVerifier, error) {
+	if len(issuers) == 0 {
+		return nil, &ConfigurationError{Message: "JWT verifier requires at least one trusted issuer"}
 	}
-	return v
+
+	cfg := jwtVerifierConfig{
+		algorithms: []string{"RS256"},
+		leeway:     DefaultLeeway,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	for _, alg := range cfg.algorithms {
+		if alg == "none" || !supportedVerifyAlgorithms[alg] {
+			return nil, &ConfigurationError{Message: fmt.Sprintf("unsupported JWT algorithm %q", alg)}
+		}
+	}
+
+	return &JWTVerifier{
+		keyring:    keyring,
+		issuers:    issuers,
+		audiences:  cfg.audiences,
+		algorithms: cfg.algorithms,
+		leeway:     cfg.leeway,
+	}, nil
 }
 
-// Verify parses and verifies a JWT, returning the claims.
-// Returns InvalidTokenError if the token is malformed or the signature is invalid.
+// Verify parses and verifies a JWT, returning the claims. Every rejection is an
+// *InvalidTokenError. Policy checks (algorithm, issuer, required claims, audience,
+// kid) run on the unverified payload before key resolution, so an untrusted issuer
+// never triggers a key lookup or network I/O.
 func (v *JWTVerifier) Verify(ctx context.Context, tokenString string) (*JWTClaims, error) {
-	// Parse without verification first to extract header claims
-	parser := jwt.NewParser(
-		jwt.WithoutClaimsValidation(),
-	)
-
+	// 1. Structure: parse without verification to read the header and payload.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
 	token, _, err := parser.ParseUnverified(tokenString, jwt.MapClaims{})
 	if err != nil {
 		return nil, &InvalidTokenError{Message: fmt.Sprintf("malformed JWT: %v", err)}
@@ -259,22 +313,58 @@ func (v *JWTVerifier) Verify(ctx context.Context, tokenString string) (*JWTClaim
 		return nil, &InvalidTokenError{Message: "invalid JWT claims"}
 	}
 
-	issuer, _ := mapClaims["iss"].(string)
-	if issuer == "" {
-		return nil, &InvalidTokenError{Message: "JWT missing issuer (iss) claim"}
+	// 2. Algorithm: present, not "none", and within the allowlist.
+	alg, _ := token.Header["alg"].(string)
+	if alg == "" || alg == "none" || !stringInSlice(v.algorithms, alg) {
+		return nil, &InvalidTokenError{Message: fmt.Sprintf("disallowed JWT algorithm %q", alg)}
 	}
 
-	kid, _ := token.Header["kid"].(string)
+	// 3. Issuer: present and in the trusted set, before any key lookup.
+	issuer, _ := mapClaims["iss"].(string)
+	if issuer == "" || !stringInSlice(v.issuers, issuer) {
+		return nil, &InvalidTokenError{Message: "JWT issuer (iss) is missing or not trusted"}
+	}
 
+	// 4. Required claims (RFC 9068 §2.2): iss (checked above), sub, aud, exp, iat,
+	// and client_id must all be present.
+	if sub, _ := mapClaims["sub"].(string); sub == "" {
+		return nil, &InvalidTokenError{Message: "JWT missing subject (sub) claim"}
+	}
+	if _, ok := mapClaims["exp"].(float64); !ok {
+		return nil, &InvalidTokenError{Message: "JWT missing expiration (exp) claim"}
+	}
+	if _, ok := mapClaims["iat"].(float64); !ok {
+		return nil, &InvalidTokenError{Message: "JWT missing issued-at (iat) claim"}
+	}
+	if clientID, _ := mapClaims["client_id"].(string); clientID == "" {
+		return nil, &InvalidTokenError{Message: "JWT missing client_id claim"}
+	}
+	aud := audienceFromClaims(mapClaims)
+	if len(aud) == 0 {
+		return nil, &InvalidTokenError{Message: "JWT missing audience (aud) claim"}
+	}
+
+	// 6. Audience binding: when audiences are configured, aud must intersect them.
+	if len(v.audiences) > 0 && !sliceIntersects(aud, v.audiences) {
+		return nil, &InvalidTokenError{Message: "JWT audience (aud) is not accepted"}
+	}
+
+	// 7. Key id: present.
+	kid, _ := token.Header["kid"].(string)
+	if kid == "" {
+		return nil, &InvalidTokenError{Message: "JWT missing key id (kid) header"}
+	}
+
+	// 8. Key resolution for (iss, kid) through the verification keyring.
 	publicKey, err := v.keyring.Key(ctx, issuer, kid)
 	if err != nil {
 		return nil, &InvalidTokenError{Message: fmt.Sprintf("failed to resolve key: %v", err)}
 	}
 
-	// Re-parse with signature verification and claims validation (exp, nbf, iat).
-	verifiedToken, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
+	// 5 + 9. Temporal (exp, nbf with leeway) and signature, with alg pinned to the allowlist.
+	verifiedToken, err := jwt.Parse(tokenString, func(_ *jwt.Token) (any, error) {
 		return publicKey, nil
-	}, jwt.WithLeeway(v.leeway))
+	}, jwt.WithValidMethods(v.algorithms), jwt.WithLeeway(v.leeway))
 	if err != nil {
 		return nil, &InvalidTokenError{Message: fmt.Sprintf("JWT verification failed: %v", err)}
 	}
@@ -285,4 +375,45 @@ func (v *JWTVerifier) Verify(ctx context.Context, tokenString string) (*JWTClaim
 	}
 
 	return jwtClaimsFromMap(verifiedClaims), nil
+}
+
+// stringInSlice reports whether v is present in set.
+func stringInSlice(set []string, v string) bool {
+	for _, s := range set {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// sliceIntersects reports whether a and b share at least one element.
+func sliceIntersects(a, b []string) bool {
+	for _, x := range a {
+		if stringInSlice(b, x) {
+			return true
+		}
+	}
+	return false
+}
+
+// audienceFromClaims extracts the aud claim as a list, accepting a string or an array.
+func audienceFromClaims(m jwt.MapClaims) []string {
+	switch aud := m["aud"].(type) {
+	case string:
+		if aud == "" {
+			return nil
+		}
+		return []string{aud}
+	case []any:
+		var out []string
+		for _, a := range aud {
+			if s, ok := a.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }

--- a/oauth/jwt.go
+++ b/oauth/jwt.go
@@ -325,8 +325,10 @@ func (v *JWTVerifier) Verify(ctx context.Context, tokenString string) (*JWTClaim
 		return nil, &InvalidTokenError{Message: "JWT issuer (iss) is missing or not trusted"}
 	}
 
-	// 4. Required claims (RFC 9068 §2.2): iss (checked above), sub, aud, exp, iat,
-	// and client_id must all be present.
+	// 4. Required claims (RFC 9068 §2.2 access-token profile): iss (checked above),
+	// sub, aud, exp, iat, and client_id must all be present. jti, also listed in
+	// §2.2, is intentionally not enforced here — it scopes replay tracking, not
+	// access validation.
 	if sub, _ := mapClaims["sub"].(string); sub == "" {
 		return nil, &InvalidTokenError{Message: "JWT missing subject (sub) claim"}
 	}

--- a/oauth/jwt_test.go
+++ b/oauth/jwt_test.go
@@ -7,7 +7,11 @@ import (
 	"crypto/rsa"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
+
+const testIssuer = "https://auth.example.com"
 
 type testPrivateKeyring struct {
 	key    *rsa.PrivateKey
@@ -22,23 +26,59 @@ func (r *testPrivateKeyring) Key(_ context.Context, _ string) (IdentifiableKey, 
 	}, nil
 }
 
+// staticTestKeyring implements OAuthKeyring with a fixed public key.
+type staticTestKeyring struct {
+	publicKey crypto.PublicKey
+}
+
+func (r *staticTestKeyring) Key(_ context.Context, _, _ string) (crypto.PublicKey, error) {
+	return r.publicKey, nil
+}
+
+// spyKeyring records whether key resolution was attempted, so tests can assert that
+// policy checks rejected a token before any key lookup or network I/O.
+type spyKeyring struct {
+	publicKey crypto.PublicKey
+	called    bool
+}
+
+func (r *spyKeyring) Key(_ context.Context, _, _ string) (crypto.PublicKey, error) {
+	r.called = true
+	return r.publicKey, nil
+}
+
+// validClaims returns a fully populated RFC 9068 access-token claim set. Negative
+// tests start from this and drop or alter a single claim.
+func validClaims() JWTClaims {
+	now := time.Now().Unix()
+	return JWTClaims{
+		Subject:  "user-123",
+		ClientID: "client-1",
+		Audience: []string{"https://api.example.com"},
+		Expiry:   now + 3600,
+		IssuedAt: now,
+	}
+}
+
+func newVerifier(t *testing.T, keyring OAuthKeyring, issuers []string, opts ...JWTVerifierOption) *JWTVerifier {
+	t.Helper()
+	v, err := NewJWTVerifier(keyring, issuers, opts...)
+	if err != nil {
+		t.Fatalf("NewJWTVerifier: %v", err)
+	}
+	return v
+}
+
 func TestJWTSignAndVerify(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("generating key: %v", err)
 	}
 
-	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auth.example.com"})
+	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: testIssuer})
 
-	now := time.Now().Unix()
-	claims := JWTClaims{
-		Subject:  "user-123",
-		Audience: []string{"https://api.example.com"},
-		Expiry:   now + 3600,
-		IssuedAt: now,
-		Scope:    "read write",
-		ClientID: "client-456",
-	}
+	claims := validClaims()
+	claims.Scope = "read write"
 
 	token, err := signer.Sign(context.Background(), claims)
 	if err != nil {
@@ -49,17 +89,15 @@ func TestJWTSignAndVerify(t *testing.T) {
 		t.Fatal("token should not be empty")
 	}
 
-	// Verify with a keyring that returns the public key
-	keyring := &staticTestKeyring{publicKey: &privateKey.PublicKey}
-	verifier := NewJWTVerifier(keyring)
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &privateKey.PublicKey}, []string{testIssuer})
 
 	verified, err := verifier.Verify(context.Background(), token)
 	if err != nil {
 		t.Fatalf("verifying: %v", err)
 	}
 
-	if verified.Issuer != "https://auth.example.com" {
-		t.Errorf("issuer: got %q, want %q", verified.Issuer, "https://auth.example.com")
+	if verified.Issuer != testIssuer {
+		t.Errorf("issuer: got %q, want %q", verified.Issuer, testIssuer)
 	}
 	if verified.Subject != "user-123" {
 		t.Errorf("subject: got %q, want %q", verified.Subject, "user-123")
@@ -67,8 +105,8 @@ func TestJWTSignAndVerify(t *testing.T) {
 	if verified.Scope != "read write" {
 		t.Errorf("scope: got %q, want %q", verified.Scope, "read write")
 	}
-	if verified.ClientID != "client-456" {
-		t.Errorf("client_id: got %q, want %q", verified.ClientID, "client-456")
+	if verified.ClientID != "client-1" {
+		t.Errorf("client_id: got %q, want %q", verified.ClientID, "client-1")
 	}
 }
 
@@ -76,16 +114,13 @@ func TestJWTSignerSetsIssuerFromKeyring(t *testing.T) {
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auto-issuer.example.com"})
 
-	// Sign without setting issuer in claims (but include expiry for validation)
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject: "user-123",
-		Expiry:  time.Now().Unix() + 3600,
-	})
+	// Sign without setting issuer in claims; the signer fills it from the keyring.
+	token, err := signer.Sign(context.Background(), validClaims())
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &privateKey.PublicKey})
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &privateKey.PublicKey}, []string{"https://auto-issuer.example.com"})
 	verified, err := verifier.Verify(context.Background(), token)
 	if err != nil {
 		t.Fatalf("verifying: %v", err)
@@ -100,16 +135,13 @@ func TestJWTVerifier_InvalidSignature(t *testing.T) {
 	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	wrongKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 
-	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: "https://auth.example.com"})
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject: "user-123",
-		Expiry:  time.Now().Unix() + 3600,
-	})
+	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: testIssuer})
+	token, err := signer.Sign(context.Background(), validClaims())
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &wrongKey.PublicKey})
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &wrongKey.PublicKey}, []string{testIssuer})
 	_, err = verifier.Verify(context.Background(), token)
 	if err == nil {
 		t.Fatal("expected error for invalid signature")
@@ -123,38 +155,196 @@ func TestJWTVerifier_InvalidSignature(t *testing.T) {
 func TestJWTVerifier_MissingIssuer(t *testing.T) {
 	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 
-	// Create a token without an issuer
+	// Token signed without an issuer claim.
 	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: ""})
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject: "user-123",
-		Expiry:  time.Now().Unix() + 3600,
-	})
+	token, err := signer.Sign(context.Background(), validClaims())
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &signingKey.PublicKey})
+	keyring := &spyKeyring{publicKey: &signingKey.PublicKey}
+	verifier := newVerifier(t, keyring, []string{testIssuer})
 	_, err = verifier.Verify(context.Background(), token)
 	if err == nil {
 		t.Fatal("expected error for missing issuer")
+	}
+	if keyring.called {
+		t.Error("key lookup must not occur for a token with no issuer")
+	}
+}
+
+func TestJWTVerifier_UntrustedIssuer(t *testing.T) {
+	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: "https://evil.example.com"})
+	token, err := signer.Sign(context.Background(), validClaims())
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+
+	keyring := &spyKeyring{publicKey: &signingKey.PublicKey}
+	verifier := newVerifier(t, keyring, []string{testIssuer})
+	_, err = verifier.Verify(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error for untrusted issuer")
+	}
+	if _, ok := err.(*InvalidTokenError); !ok {
+		t.Errorf("expected InvalidTokenError, got %T: %v", err, err)
+	}
+	if keyring.called {
+		t.Error("key lookup must not occur for an untrusted issuer")
+	}
+}
+
+func TestJWTVerifier_AlgorithmNoneRejected(t *testing.T) {
+	keyring := &spyKeyring{}
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"iss":       testIssuer,
+		"sub":       "user-123",
+		"client_id": "client-1",
+		"aud":       "https://api.example.com",
+		"iat":       time.Now().Unix(),
+		"exp":       time.Now().Add(time.Hour).Unix(),
+	})
+	tok.Header["kid"] = "test-key-1"
+	token, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("signing none token: %v", err)
+	}
+
+	verifier := newVerifier(t, keyring, []string{testIssuer})
+	_, err = verifier.Verify(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error for alg=none")
+	}
+	if keyring.called {
+		t.Error("key lookup must not occur for alg=none")
+	}
+}
+
+func TestJWTVerifier_AlgorithmOutsideAllowlist(t *testing.T) {
+	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: testIssuer})
+	token, err := signer.Sign(context.Background(), validClaims())
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+
+	// Token is RS256, but the verifier only allows ES256.
+	keyring := &spyKeyring{publicKey: &signingKey.PublicKey}
+	verifier := newVerifier(t, keyring, []string{testIssuer}, WithAlgorithms("ES256"))
+	_, err = verifier.Verify(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error for algorithm outside the allowlist")
+	}
+	if keyring.called {
+		t.Error("key lookup must not occur for a disallowed algorithm")
+	}
+}
+
+func TestJWTVerifier_MissingRequiredClaims(t *testing.T) {
+	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: testIssuer})
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &signingKey.PublicKey}, []string{testIssuer})
+
+	cases := map[string]func(*JWTClaims){
+		"missing sub":       func(c *JWTClaims) { c.Subject = "" },
+		"missing client_id": func(c *JWTClaims) { c.ClientID = "" },
+		"missing aud":       func(c *JWTClaims) { c.Audience = nil },
+		"missing exp":       func(c *JWTClaims) { c.Expiry = 0 },
+		"missing iat":       func(c *JWTClaims) { c.IssuedAt = 0 },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			claims := validClaims()
+			mutate(&claims)
+			token, err := signer.Sign(context.Background(), claims)
+			if err != nil {
+				t.Fatalf("signing: %v", err)
+			}
+			if _, err := verifier.Verify(context.Background(), token); err == nil {
+				t.Fatalf("expected error for %s", name)
+			}
+		})
+	}
+}
+
+func TestJWTVerifier_MissingKid(t *testing.T) {
+	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	// Sign directly so the kid header is omitted, with otherwise valid claims.
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss":       testIssuer,
+		"sub":       "user-123",
+		"client_id": "client-1",
+		"aud":       "https://api.example.com",
+		"iat":       time.Now().Unix(),
+		"exp":       time.Now().Add(time.Hour).Unix(),
+	})
+	token, err := tok.SignedString(signingKey)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+
+	keyring := &spyKeyring{publicKey: &signingKey.PublicKey}
+	verifier := newVerifier(t, keyring, []string{testIssuer})
+	_, err = verifier.Verify(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error for missing kid header")
+	}
+	if keyring.called {
+		t.Error("key lookup must not occur when kid is missing")
+	}
+}
+
+func TestJWTVerifier_AudienceNoIntersection(t *testing.T) {
+	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: testIssuer})
+	claims := validClaims()
+	claims.Audience = []string{"https://other.example.com"}
+	token, err := signer.Sign(context.Background(), claims)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &signingKey.PublicKey},
+		[]string{testIssuer}, WithAudiences("https://api.example.com"))
+	_, err = verifier.Verify(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected error when aud does not intersect the configured audiences")
+	}
+}
+
+func TestJWTVerifier_AudienceMatch(t *testing.T) {
+	signingKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	signer := NewJWTSigner(&testPrivateKeyring{key: signingKey, issuer: testIssuer})
+	claims := validClaims()
+	claims.Audience = []string{"https://api.example.com", "https://other.example.com"}
+	token, err := signer.Sign(context.Background(), claims)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &signingKey.PublicKey},
+		[]string{testIssuer}, WithAudiences("https://api.example.com"))
+	if _, err := verifier.Verify(context.Background(), token); err != nil {
+		t.Fatalf("token with intersecting audience should verify: %v", err)
 	}
 }
 
 func TestJWTVerifier_ExpiredToken(t *testing.T) {
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auth.example.com"})
+	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: testIssuer})
 
-	// Token expired 1 hour ago (well beyond leeway)
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject:  "user-123",
-		Expiry:   time.Now().Unix() - 3600,
-		IssuedAt: time.Now().Unix() - 7200,
-	})
+	// Token expired 1 hour ago (well beyond leeway).
+	claims := validClaims()
+	claims.Expiry = time.Now().Unix() - 3600
+	claims.IssuedAt = time.Now().Unix() - 7200
+	token, err := signer.Sign(context.Background(), claims)
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &privateKey.PublicKey})
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &privateKey.PublicKey}, []string{testIssuer})
 	_, err = verifier.Verify(context.Background(), token)
 	if err == nil {
 		t.Fatal("expected error for expired token")
@@ -167,20 +357,18 @@ func TestJWTVerifier_ExpiredToken(t *testing.T) {
 
 func TestJWTVerifier_NotYetValid(t *testing.T) {
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auth.example.com"})
+	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: testIssuer})
 
-	// Token not valid until 1 hour from now (well beyond leeway)
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject:   "user-123",
-		NotBefore: time.Now().Unix() + 3600,
-		Expiry:    time.Now().Unix() + 7200,
-		IssuedAt:  time.Now().Unix(),
-	})
+	// Token not valid until 1 hour from now (well beyond leeway).
+	claims := validClaims()
+	claims.NotBefore = time.Now().Unix() + 3600
+	claims.Expiry = time.Now().Unix() + 7200
+	token, err := signer.Sign(context.Background(), claims)
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &privateKey.PublicKey})
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &privateKey.PublicKey}, []string{testIssuer})
 	_, err = verifier.Verify(context.Background(), token)
 	if err == nil {
 		t.Fatal("expected error for not-yet-valid token")
@@ -191,43 +379,20 @@ func TestJWTVerifier_NotYetValid(t *testing.T) {
 	}
 }
 
-func TestJWTVerifier_FutureIssuedAt(t *testing.T) {
-	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auth.example.com"})
-
-	// Token issued 1 hour in the future (well beyond leeway)
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject:  "user-123",
-		IssuedAt: time.Now().Unix() + 3600,
-		Expiry:   time.Now().Unix() + 7200,
-	})
-	if err != nil {
-		t.Fatalf("signing: %v", err)
-	}
-
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &privateKey.PublicKey})
-	_, err = verifier.Verify(context.Background(), token)
-	// golang-jwt/v5 does not reject future iat by default; only exp and nbf are enforced.
-	// This is consistent with RFC 7519 which does not mandate iat rejection.
-	// If this passes, that's acceptable. If it fails, that's also fine.
-	_ = err
-}
-
 func TestJWTVerifier_WithinLeeway(t *testing.T) {
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auth.example.com"})
+	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: testIssuer})
 
-	// Token expired 30 seconds ago — within the default 60s leeway
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject:  "user-123",
-		Expiry:   time.Now().Unix() - 30,
-		IssuedAt: time.Now().Unix() - 3600,
-	})
+	// Token expired 30 seconds ago, within the default 60s leeway.
+	claims := validClaims()
+	claims.Expiry = time.Now().Unix() - 30
+	claims.IssuedAt = time.Now().Unix() - 3600
+	token, err := signer.Sign(context.Background(), claims)
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	verifier := NewJWTVerifier(&staticTestKeyring{publicKey: &privateKey.PublicKey})
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &privateKey.PublicKey}, []string{testIssuer})
 	_, err = verifier.Verify(context.Background(), token)
 	if err != nil {
 		t.Fatalf("token expired by 30s should be accepted within 60s leeway: %v", err)
@@ -236,26 +401,41 @@ func TestJWTVerifier_WithinLeeway(t *testing.T) {
 
 func TestJWTVerifier_CustomLeeway(t *testing.T) {
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
-	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: "https://auth.example.com"})
+	signer := NewJWTSigner(&testPrivateKeyring{key: privateKey, issuer: testIssuer})
 
-	// Token expired 30 seconds ago
-	token, err := signer.Sign(context.Background(), JWTClaims{
-		Subject:  "user-123",
-		Expiry:   time.Now().Unix() - 30,
-		IssuedAt: time.Now().Unix() - 3600,
-	})
+	// Token expired 30 seconds ago.
+	claims := validClaims()
+	claims.Expiry = time.Now().Unix() - 30
+	claims.IssuedAt = time.Now().Unix() - 3600
+	token, err := signer.Sign(context.Background(), claims)
 	if err != nil {
 		t.Fatalf("signing: %v", err)
 	}
 
-	// Use a 10-second leeway — token expired 30s ago should be rejected
-	verifier := NewJWTVerifier(
-		&staticTestKeyring{publicKey: &privateKey.PublicKey},
-		WithVerifierLeeway(10*time.Second),
-	)
+	// A 10-second leeway rejects a token that expired 30s ago.
+	verifier := newVerifier(t, &staticTestKeyring{publicKey: &privateKey.PublicKey},
+		[]string{testIssuer}, WithVerifierLeeway(10*time.Second))
 	_, err = verifier.Verify(context.Background(), token)
 	if err == nil {
 		t.Fatal("token expired by 30s should be rejected with 10s leeway")
+	}
+}
+
+func TestNewJWTVerifier_ConfigurationErrors(t *testing.T) {
+	keyring := &staticTestKeyring{}
+
+	if _, err := NewJWTVerifier(keyring, nil); err == nil {
+		t.Error("expected configuration error for empty issuers")
+	} else if _, ok := err.(*ConfigurationError); !ok {
+		t.Errorf("expected ConfigurationError, got %T: %v", err, err)
+	}
+
+	if _, err := NewJWTVerifier(keyring, []string{testIssuer}, WithAlgorithms("none")); err == nil {
+		t.Error("expected configuration error for alg=none")
+	}
+
+	if _, err := NewJWTVerifier(keyring, []string{testIssuer}, WithAlgorithms("HS256")); err == nil {
+		t.Error("expected configuration error for an unsupported algorithm")
 	}
 }
 
@@ -291,7 +471,7 @@ func TestJWTClaims_Accessors(t *testing.T) {
 		t.Errorf("GetNotBefore: got %v, want %d", nbf, now-60)
 	}
 
-	// Zero values should return nil
+	// Zero values should return nil.
 	empty := JWTClaims{}
 	exp, _ = empty.GetExpirationTime()
 	if exp != nil {
@@ -305,13 +485,4 @@ func TestJWTClaims_Accessors(t *testing.T) {
 	if nbf != nil {
 		t.Errorf("zero NotBefore should return nil, got %v", nbf)
 	}
-}
-
-// staticTestKeyring implements OAuthKeyring with a fixed public key.
-type staticTestKeyring struct {
-	publicKey crypto.PublicKey
-}
-
-func (r *staticTestKeyring) Key(_ context.Context, _, _ string) (crypto.PublicKey, error) {
-	return r.publicKey, nil
 }


### PR DESCRIPTION
## What

Brings the Go JWT verifier to the [`jwt-signing-and-verification`](https://github.com/keycardai/keycard-sdk-spec/blob/main/specs/jwt-jwks/jwt-signing-and-verification.md) spec contract, closing the security gaps the spec tracks for the Go verifier. First step of the Go SDK parity effort (M3).

## Why

The verifier was not fail-closed: `NewJWTVerifier(keyring)` took no issuers/audiences/algorithms, and `Verify` only checked that `iss` was non-empty — no issuer allowlist, no audience check, no algorithm allowlist, `kid` optional, and none of the RFC 9068 required claims. A token carrying an attacker-controlled `iss` could drive key lookup to an untrusted endpoint.

## Changes

- **Fail-closed ordering:** algorithm and issuer are validated on the unverified payload *before* any key resolution or network I/O, then required claims → audience → `kid` → key resolution → signature.
- **Issuer allowlist required:** `NewJWTVerifier(keyring, issuers, opts...)` returns a `ConfigurationError` on empty issuers or an unsupported algorithm.
- **New options:** `WithAudiences`, `WithAlgorithms` (default `["RS256"]`, `none` always rejected), alongside `WithVerifierLeeway`.
- **RFC 9068 §2.2 required claims:** `iss`, `sub`, `aud`, `exp`, `iat`, `client_id` — matching Python and TS. Audience *intersection* is enforced only when audiences are configured.
- **Bearer surface (spec's intended Go idiom — verifier-first):** `RequireBearerAuth(verifier, opts...)` takes the verifier as a required positional argument; trusted issuers and audience live on the verifier, not the middleware. `NewZoneTokenVerifier(zoneURL, ...)` is the single-zone convenience. A nil verifier panics at construction (a wiring bug on a security boundary, caught at startup).

## Breaking changes

- `NewJWTVerifier(keyring)` → `NewJWTVerifier(keyring, issuers, opts...) (*JWTVerifier, error)`
- `NewJWTOAuthTokenVerifier(keyring)` → `NewJWTOAuthTokenVerifier(keyring, issuers, opts...) (*JWTOAuthTokenVerifier, error)`
- `RequireBearerAuth(opts...)` → `RequireBearerAuth(verifier, opts...)` (the `WithVerifier` option is removed)

Acceptable under the v0.x preview label.

## Tests

Table-driven conformance cases from the spec's Testing section: rejection of `alg=none` / disallowed algorithm / untrusted issuer (all before key lookup, asserted via a spy keyring), each missing RFC 9068 claim, missing `kid`, audience missing / non-intersecting, expired / not-yet-valid, within / outside leeway, and construction errors. `go vet`, `go test -race`, and `go build ./examples/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
