### PR TITLE
feat: add authorization-code-with-PKCE flow (ECO-90)

### DIFF
--- a/examples/authorization-code-pkce/main.go
+++ b/examples/authorization-code-pkce/main.go
@@ -1,0 +1,45 @@
+// Package main demonstrates the authorization-code-with-PKCE login flow: it opens
+// the browser, runs a loopback callback server, and exchanges the code for a token.
+//
+// Configure in Keycard before running:
+//   - A zone (KEYCARD_ZONE_URL), e.g. https://your-zone.keycard.cloud
+//   - A public OAuth client (KEYCARD_CLIENT_ID) registered with token-endpoint auth
+//     method "none" and the loopback redirect URI http://127.0.0.1:8765/callback
+//
+// Run:
+//
+//	KEYCARD_ZONE_URL=... KEYCARD_CLIENT_ID=... go run ./examples/authorization-code-pkce
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+func main() {
+	zoneURL := os.Getenv("KEYCARD_ZONE_URL")
+	clientID := os.Getenv("KEYCARD_CLIENT_ID")
+	if zoneURL == "" || clientID == "" {
+		log.Fatal("KEYCARD_ZONE_URL and KEYCARD_CLIENT_ID environment variables are required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	fmt.Println("Opening your browser to sign in...")
+	token, err := oauth.Authenticate(ctx, zoneURL, oauth.AuthenticateRequest{
+		ClientID: clientID,
+		Scopes:   []string{"openid"},
+	})
+	if err != nil {
+		log.Fatalf("authentication failed: %v", err)
+	}
+
+	fmt.Printf("Signed in. Token type %s, expires in %ds.\n", token.TokenType, token.ExpiresIn)
+	fmt.Println(token.AccessToken)
+}

--- a/oauth/authorization_code.go
+++ b/oauth/authorization_code.go
@@ -1,0 +1,439 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Loopback flow defaults (RFC 8252), aligned with the Python and TS SDKs.
+const (
+	defaultCallbackPort    = 8765
+	defaultCallbackTimeout = 300 * time.Second
+	defaultCallbackPath    = "/callback"
+)
+
+// AuthorizeURLParams are the inputs to BuildAuthorizeURL.
+type AuthorizeURLParams struct {
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string   // defaults to S256 when empty
+	Scopes              []string // optional; space-joined on the wire
+	State               string   // optional CSRF token
+	Resource            string   // optional RFC 8707 resource indicator
+}
+
+// BuildAuthorizeURL builds an authorization-code request URL against the given
+// authorization endpoint (RFC 6749 §4.1.1 with the RFC 7636 PKCE parameters).
+func BuildAuthorizeURL(authorizationEndpoint string, params AuthorizeURLParams) (string, error) {
+	u, err := url.Parse(authorizationEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("parsing authorization endpoint: %w", err)
+	}
+
+	method := params.CodeChallengeMethod
+	if method == "" {
+		method = PKCEMethodS256
+	}
+
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", params.ClientID)
+	q.Set("redirect_uri", params.RedirectURI)
+	q.Set("code_challenge", params.CodeChallenge)
+	q.Set("code_challenge_method", method)
+	if len(params.Scopes) > 0 {
+		q.Set("scope", strings.Join(params.Scopes, " "))
+	}
+	if params.State != "" {
+		q.Set("state", params.State)
+	}
+	if params.Resource != "" {
+		q.Set("resource", params.Resource)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// AuthorizationCodeExchangeRequest exchanges an authorization code for a token.
+// A public client sets ClientID (sent in the body); a confidential client sets
+// ClientSecret as well and is authenticated with HTTP Basic, with ClientID omitted
+// from the body.
+type AuthorizationCodeExchangeRequest struct {
+	Code         string
+	CodeVerifier string
+	RedirectURI  string
+	ClientID     string
+	ClientSecret string
+	Resource     string // optional RFC 8707 resource indicator
+}
+
+// AuthCodeExchangeOption configures ExchangeAuthorizationCode.
+type AuthCodeExchangeOption func(*authCodeExchangeConfig)
+
+type authCodeExchangeConfig struct {
+	httpClient *http.Client
+}
+
+// WithAuthCodeHTTPClient sets the HTTP client used for discovery and code exchange.
+func WithAuthCodeHTTPClient(c *http.Client) AuthCodeExchangeOption {
+	return func(cfg *authCodeExchangeConfig) { cfg.httpClient = c }
+}
+
+// ExchangeAuthorizationCode exchanges an authorization code at the issuer's token
+// endpoint (resolved by discovery) for a token. The response has the same shape as
+// Token Exchange.
+func ExchangeAuthorizationCode(ctx context.Context, issuer string, req AuthorizationCodeExchangeRequest, opts ...AuthCodeExchangeOption) (*TokenResponse, error) {
+	cfg := authCodeExchangeConfig{httpClient: http.DefaultClient}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	tokenEndpoint, err := resolveTokenEndpoint(ctx, issuer, cfg.httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return exchangeCodeAtEndpoint(ctx, tokenEndpoint, req, cfg.httpClient)
+}
+
+func resolveTokenEndpoint(ctx context.Context, issuer string, httpClient *http.Client) (string, error) {
+	metadata, err := FetchAuthorizationServerMetadata(ctx, issuer, WithDiscoveryHTTPClient(httpClient))
+	if err != nil {
+		return "", fmt.Errorf("discovering token endpoint: %w", err)
+	}
+	if metadata.TokenEndpoint == "" {
+		return "", fmt.Errorf("authorization server %q does not advertise a token_endpoint", issuer)
+	}
+	return metadata.TokenEndpoint, nil
+}
+
+func exchangeCodeAtEndpoint(ctx context.Context, tokenEndpoint string, req AuthorizationCodeExchangeRequest, httpClient *http.Client) (*TokenResponse, error) {
+	body := url.Values{}
+	body.Set("grant_type", "authorization_code")
+	body.Set("code", req.Code)
+	body.Set("code_verifier", req.CodeVerifier)
+	body.Set("redirect_uri", req.RedirectURI)
+	if req.Resource != "" {
+		body.Set("resource", req.Resource)
+	}
+
+	confidential := req.ClientSecret != ""
+	if !confidential && req.ClientID != "" {
+		body.Set("client_id", req.ClientID)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(body.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating code exchange request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if confidential {
+		httpReq.SetBasicAuth(req.ClientID, req.ClientSecret)
+	}
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("code exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, oauthErrorFromResponse(resp)
+	}
+	return deserializeTokenResponse(resp)
+}
+
+// oauthErrorFromResponse converts a non-2xx token-endpoint response into an *OAuthError
+// when the body carries an RFC 6749 §5.2 error, or a generic error otherwise.
+func oauthErrorFromResponse(resp *http.Response) error {
+	var errBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
+		if errCode, ok := errBody["error"].(string); ok {
+			oauthErr := &OAuthError{ErrorCode: errCode, Message: errCode}
+			if desc, ok := errBody["error_description"].(string); ok {
+				oauthErr.Message = desc
+			}
+			if uri, ok := errBody["error_uri"].(string); ok {
+				oauthErr.ErrorURI = uri
+			}
+			return oauthErr
+		}
+	}
+	return fmt.Errorf("token endpoint returned HTTP %d", resp.StatusCode)
+}
+
+// AuthenticateRequest configures the high-level loopback login flow. Zero-valued
+// optional fields take their documented defaults.
+type AuthenticateRequest struct {
+	ClientID        string
+	Scopes          []string
+	RedirectURI     string        // default http://127.0.0.1:<CallbackPort><defaultCallbackPath>
+	CallbackPort    int           // default 8765
+	CallbackTimeout time.Duration // default 300s
+	ClientSecret    string        // set for a confidential client
+	Resource        string        // optional RFC 8707 resource indicator
+}
+
+// AuthenticateOption configures the transport and browser launcher of the high-level flow.
+type AuthenticateOption func(*authenticateConfig)
+
+type authenticateConfig struct {
+	httpClient  *http.Client
+	openBrowser func(rawURL string) error
+}
+
+// WithAuthenticateHTTPClient sets the HTTP client used for discovery and code exchange.
+func WithAuthenticateHTTPClient(c *http.Client) AuthenticateOption {
+	return func(cfg *authenticateConfig) { cfg.httpClient = c }
+}
+
+// WithBrowserOpener overrides how the authorize URL is opened. The default launches
+// the system browser; tests and headless environments can supply their own.
+func WithBrowserOpener(open func(rawURL string) error) AuthenticateOption {
+	return func(cfg *authenticateConfig) { cfg.openBrowser = open }
+}
+
+// Authenticate runs the full authorization-code-with-PKCE flow: it generates a PKCE
+// pair and CSRF state, opens the browser to the authorize URL, runs a loopback server
+// to receive the redirect, validates the returned state, and exchanges the code for a
+// token. The issuer's endpoints are resolved by discovery.
+func Authenticate(ctx context.Context, issuer string, req AuthenticateRequest, opts ...AuthenticateOption) (*TokenResponse, error) {
+	cfg := authenticateConfig{httpClient: http.DefaultClient, openBrowser: openBrowser}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	port := req.CallbackPort
+	if port == 0 {
+		port = defaultCallbackPort
+	}
+	redirectURI := req.RedirectURI
+	if redirectURI == "" {
+		redirectURI = fmt.Sprintf("http://127.0.0.1:%d%s", port, defaultCallbackPath)
+	}
+	timeout := req.CallbackTimeout
+	if timeout == 0 {
+		timeout = defaultCallbackTimeout
+	}
+
+	metadata, err := FetchAuthorizationServerMetadata(ctx, issuer, WithDiscoveryHTTPClient(cfg.httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("discovering authorization server: %w", err)
+	}
+	if metadata.AuthorizationEndpoint == "" || metadata.TokenEndpoint == "" {
+		return nil, fmt.Errorf("authorization server %q is missing an authorization or token endpoint", issuer)
+	}
+
+	pkce, err := GeneratePKCEPair()
+	if err != nil {
+		return nil, err
+	}
+	state, err := generateState()
+	if err != nil {
+		return nil, err
+	}
+
+	authorizeURL, err := BuildAuthorizeURL(metadata.AuthorizationEndpoint, AuthorizeURLParams{
+		ClientID:            req.ClientID,
+		RedirectURI:         redirectURI,
+		CodeChallenge:       pkce.CodeChallenge,
+		CodeChallengeMethod: pkce.CodeChallengeMethod,
+		Scopes:              req.Scopes,
+		State:               state,
+		Resource:            req.Resource,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	code, err := runLoopbackFlow(ctx, redirectURI, state, timeout, func() error {
+		return cfg.openBrowser(authorizeURL)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return exchangeCodeAtEndpoint(ctx, metadata.TokenEndpoint, AuthorizationCodeExchangeRequest{
+		Code:         code,
+		CodeVerifier: pkce.CodeVerifier,
+		RedirectURI:  redirectURI,
+		ClientID:     req.ClientID,
+		ClientSecret: req.ClientSecret,
+		Resource:     req.Resource,
+	}, cfg.httpClient)
+}
+
+// AuthenticateFromChallenge resolves the issuer from an RFC 9728 WWW-Authenticate
+// challenge, then runs Authenticate against it.
+func AuthenticateFromChallenge(ctx context.Context, wwwAuthenticateHeader string, req AuthenticateRequest, opts ...AuthenticateOption) (*TokenResponse, error) {
+	cfg := authenticateConfig{httpClient: http.DefaultClient}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	issuer, err := ResolveIssuerFromChallenge(ctx, wwwAuthenticateHeader, cfg.httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return Authenticate(ctx, issuer, req, opts...)
+}
+
+// ResolveIssuerFromChallenge reads the resource_metadata URL from an RFC 6750
+// WWW-Authenticate challenge, fetches the RFC 9728 protected-resource metadata, and
+// returns its first advertised authorization server. A nil httpClient uses the default.
+func ResolveIssuerFromChallenge(ctx context.Context, wwwAuthenticateHeader string, httpClient *http.Client) (string, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	metadataURL := resourceMetadataURLFromChallenge(wwwAuthenticateHeader)
+	if metadataURL == "" {
+		return "", fmt.Errorf("WWW-Authenticate challenge has no resource_metadata parameter")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating resource metadata request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("fetching resource metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", &HTTPError{Message: "fetching resource metadata", Status: resp.StatusCode}
+	}
+
+	var prm struct {
+		AuthorizationServers []string `json:"authorization_servers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&prm); err != nil {
+		return "", fmt.Errorf("decoding resource metadata: %w", err)
+	}
+	if len(prm.AuthorizationServers) == 0 {
+		return "", fmt.Errorf("resource metadata advertises no authorization servers")
+	}
+	return prm.AuthorizationServers[0], nil
+}
+
+// resourceMetadataURLFromChallenge extracts the resource_metadata="<url>" parameter
+// from a WWW-Authenticate header value.
+func resourceMetadataURLFromChallenge(header string) string {
+	const key = `resource_metadata="`
+	i := strings.Index(header, key)
+	if i < 0 {
+		return ""
+	}
+	rest := header[i+len(key):]
+	j := strings.IndexByte(rest, '"')
+	if j < 0 {
+		return ""
+	}
+	return rest[:j]
+}
+
+// runLoopbackFlow starts a loopback HTTP server at redirectURI, invokes open to launch
+// the browser, and waits for the redirect carrying the authorization code. It validates
+// that the returned state matches and that no error parameter was sent.
+func runLoopbackFlow(ctx context.Context, redirectURI, wantState string, timeout time.Duration, open func() error) (string, error) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		return "", fmt.Errorf("parsing redirect URI: %w", err)
+	}
+	path := u.Path
+	if path == "" {
+		path = defaultCallbackPath
+	}
+
+	listener, err := net.Listen("tcp", u.Host)
+	if err != nil {
+		return "", fmt.Errorf("starting loopback listener on %s: %w", u.Host, err)
+	}
+
+	type result struct {
+		code string
+		err  error
+	}
+	resultCh := make(chan result, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if oauthErr := q.Get("error"); oauthErr != "" {
+			http.Error(w, "Authentication failed. You can close this window.", http.StatusBadRequest)
+			oe := &OAuthError{ErrorCode: oauthErr, Message: oauthErr}
+			if desc := q.Get("error_description"); desc != "" {
+				oe.Message = desc
+			}
+			resultCh <- result{err: oe}
+			return
+		}
+		if q.Get("state") != wantState {
+			http.Error(w, "Authentication failed. You can close this window.", http.StatusBadRequest)
+			resultCh <- result{err: fmt.Errorf("authorization-code callback state mismatch")}
+			return
+		}
+		code := q.Get("code")
+		if code == "" {
+			http.Error(w, "Authentication failed. You can close this window.", http.StatusBadRequest)
+			resultCh <- result{err: fmt.Errorf("authorization-code callback missing code")}
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte("Authentication complete. You can close this window."))
+		resultCh <- result{code: code}
+	})
+
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(listener) }()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	if err := open(); err != nil {
+		return "", fmt.Errorf("opening browser: %w", err)
+	}
+
+	select {
+	case res := <-resultCh:
+		return res.code, res.err
+	case <-time.After(timeout):
+		return "", fmt.Errorf("timed out after %s waiting for the authorization redirect", timeout)
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func generateState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating state: %w", err)
+	}
+	return Base64URLEncode(b), nil
+}
+
+// openBrowser launches the system browser without a shell (exec.Command does not
+// invoke a shell, so the URL is not subject to shell interpretation).
+func openBrowser(rawURL string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", rawURL).Start()
+	case "windows":
+		// The empty argument is the window title that "start" expects first.
+		return exec.Command("cmd", "/c", "start", "", rawURL).Start()
+	default:
+		return exec.Command("xdg-open", rawURL).Start()
+	}
+}

--- a/oauth/authorization_code.go
+++ b/oauth/authorization_code.go
@@ -368,6 +368,14 @@ func runLoopbackFlow(ctx context.Context, redirectURI, wantState string, timeout
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		// The authorization server delivers the code via a browser GET redirect.
+		// Ignore any other method (an OPTIONS probe, a scanner, a stray request) so
+		// it cannot consume the one-shot result channel and abort the flow.
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		q := r.URL.Query()
 		if oauthErr := q.Get("error"); oauthErr != "" {
 			http.Error(w, "Authentication failed. You can close this window.", http.StatusBadRequest)

--- a/oauth/authorization_code_test.go
+++ b/oauth/authorization_code_test.go
@@ -250,6 +250,49 @@ func TestAuthenticate_StateMismatchRejected(t *testing.T) {
 	}
 }
 
+func TestAuthenticate_IgnoresNonGetCallback(t *testing.T) {
+	as := newAuthServer()
+	defer as.Close()
+
+	// A stray non-GET probe (e.g. OPTIONS) to the callback must not consume the
+	// result channel and abort the flow; the real GET redirect still completes it.
+	opener := func(rawURL string) error {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return err
+		}
+		state := u.Query().Get("state")
+		cb, err := url.Parse(u.Query().Get("redirect_uri"))
+		if err != nil {
+			return err
+		}
+		go func() {
+			req, _ := http.NewRequest(http.MethodOptions, cb.String(), nil)
+			if resp, err := http.DefaultClient.Do(req); err == nil {
+				resp.Body.Close()
+			}
+			q := cb.Query()
+			q.Set("code", "loopback-code")
+			q.Set("state", state)
+			cb.RawQuery = q.Encode()
+			if resp, err := http.Get(cb.String()); err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	tok, err := Authenticate(context.Background(), as.URL, AuthenticateRequest{
+		ClientID: "public-client",
+	}, WithAuthenticateHTTPClient(as.Client()), WithBrowserOpener(opener))
+	if err != nil {
+		t.Fatalf("non-GET probe should be ignored and the flow should complete: %v", err)
+	}
+	if tok.AccessToken != "at" {
+		t.Errorf("access token: got %q, want at", tok.AccessToken)
+	}
+}
+
 func TestResolveIssuerFromChallenge(t *testing.T) {
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)

--- a/oauth/authorization_code_test.go
+++ b/oauth/authorization_code_test.go
@@ -1,0 +1,278 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// authServer is a test authorization server: it serves discovery metadata pointing at
+// its own /authorize and /token, and records the last token-endpoint request.
+type authServer struct {
+	*httptest.Server
+	lastForm     url.Values
+	lastAuthUser string // HTTP Basic username, if any
+	lastAuthOK   bool
+	tokenStatus  int
+	tokenBody    string
+}
+
+func newAuthServer() *authServer {
+	as := &authServer{tokenStatus: http.StatusOK, tokenBody: `{"access_token":"at","token_type":"Bearer","expires_in":3600}`}
+	mux := http.NewServeMux()
+	as.Server = httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 as.URL,
+			"authorization_endpoint": as.URL + "/authorize",
+			"token_endpoint":         as.URL + "/token",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		as.lastForm = r.PostForm
+		as.lastAuthUser, _, as.lastAuthOK = r.BasicAuth()
+		w.WriteHeader(as.tokenStatus)
+		_, _ = w.Write([]byte(as.tokenBody))
+	})
+	return as
+}
+
+func TestBuildAuthorizeURL(t *testing.T) {
+	raw, err := BuildAuthorizeURL("https://zone.example.com/authorize", AuthorizeURLParams{
+		ClientID:            "client-1",
+		RedirectURI:         "http://127.0.0.1:8765/callback",
+		CodeChallenge:       "challenge-value",
+		CodeChallengeMethod: PKCEMethodS256,
+		Scopes:              []string{"openid", "mcp:tools"},
+		State:               "state-123",
+		Resource:            "https://api.example.com",
+	})
+	if err != nil {
+		t.Fatalf("BuildAuthorizeURL: %v", err)
+	}
+	u, _ := url.Parse(raw)
+	q := u.Query()
+	checks := map[string]string{
+		"response_type":         "code",
+		"client_id":             "client-1",
+		"redirect_uri":          "http://127.0.0.1:8765/callback",
+		"code_challenge":        "challenge-value",
+		"code_challenge_method": "S256",
+		"scope":                 "openid mcp:tools",
+		"state":                 "state-123",
+		"resource":              "https://api.example.com",
+	}
+	for k, want := range checks {
+		if got := q.Get(k); got != want {
+			t.Errorf("query %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestBuildAuthorizeURL_DefaultsMethodAndOmitsEmptyScope(t *testing.T) {
+	raw, err := BuildAuthorizeURL("https://zone.example.com/authorize", AuthorizeURLParams{
+		ClientID:      "client-1",
+		RedirectURI:   "http://127.0.0.1:8765/callback",
+		CodeChallenge: "challenge-value",
+	})
+	if err != nil {
+		t.Fatalf("BuildAuthorizeURL: %v", err)
+	}
+	q, _ := url.Parse(raw)
+	if q.Query().Get("code_challenge_method") != PKCEMethodS256 {
+		t.Errorf("method should default to S256, got %q", q.Query().Get("code_challenge_method"))
+	}
+	if _, ok := q.Query()["scope"]; ok {
+		t.Error("scope should be omitted when no scopes are set")
+	}
+}
+
+func TestExchangeAuthorizationCode_PublicClient(t *testing.T) {
+	as := newAuthServer()
+	defer as.Close()
+
+	tok, err := ExchangeAuthorizationCode(context.Background(), as.URL, AuthorizationCodeExchangeRequest{
+		Code:         "auth-code",
+		CodeVerifier: "verifier",
+		RedirectURI:  "http://127.0.0.1:8765/callback",
+		ClientID:     "public-client",
+	}, WithAuthCodeHTTPClient(as.Client()))
+	if err != nil {
+		t.Fatalf("ExchangeAuthorizationCode: %v", err)
+	}
+	if tok.AccessToken != "at" {
+		t.Errorf("access token: got %q, want at", tok.AccessToken)
+	}
+
+	if as.lastForm.Get("grant_type") != "authorization_code" {
+		t.Errorf("grant_type: got %q", as.lastForm.Get("grant_type"))
+	}
+	if as.lastForm.Get("code") != "auth-code" {
+		t.Errorf("code: got %q", as.lastForm.Get("code"))
+	}
+	if as.lastForm.Get("code_verifier") != "verifier" {
+		t.Errorf("code_verifier: got %q", as.lastForm.Get("code_verifier"))
+	}
+	if as.lastForm.Get("redirect_uri") != "http://127.0.0.1:8765/callback" {
+		t.Errorf("redirect_uri: got %q", as.lastForm.Get("redirect_uri"))
+	}
+	if as.lastForm.Get("client_id") != "public-client" {
+		t.Errorf("public client should send client_id in the body, got %q", as.lastForm.Get("client_id"))
+	}
+	if as.lastAuthOK {
+		t.Error("public client should not send HTTP Basic auth")
+	}
+}
+
+func TestExchangeAuthorizationCode_ConfidentialClient(t *testing.T) {
+	as := newAuthServer()
+	defer as.Close()
+
+	_, err := ExchangeAuthorizationCode(context.Background(), as.URL, AuthorizationCodeExchangeRequest{
+		Code:         "auth-code",
+		CodeVerifier: "verifier",
+		RedirectURI:  "http://127.0.0.1:8765/callback",
+		ClientID:     "confidential-client",
+		ClientSecret: "secret",
+	}, WithAuthCodeHTTPClient(as.Client()))
+	if err != nil {
+		t.Fatalf("ExchangeAuthorizationCode: %v", err)
+	}
+
+	if !as.lastAuthOK || as.lastAuthUser != "confidential-client" {
+		t.Errorf("confidential client should authenticate with HTTP Basic, got user %q ok=%v", as.lastAuthUser, as.lastAuthOK)
+	}
+	if as.lastForm.Get("client_id") != "" {
+		t.Errorf("confidential client should not duplicate client_id in the body, got %q", as.lastForm.Get("client_id"))
+	}
+}
+
+func TestExchangeAuthorizationCode_OAuthError(t *testing.T) {
+	as := newAuthServer()
+	defer as.Close()
+	as.tokenStatus = http.StatusBadRequest
+	as.tokenBody = `{"error":"invalid_grant","error_description":"code expired"}`
+
+	_, err := ExchangeAuthorizationCode(context.Background(), as.URL, AuthorizationCodeExchangeRequest{
+		Code:         "expired-code",
+		CodeVerifier: "verifier",
+		RedirectURI:  "http://127.0.0.1:8765/callback",
+		ClientID:     "public-client",
+	}, WithAuthCodeHTTPClient(as.Client()))
+	if err == nil {
+		t.Fatal("expected an error for the OAuth error response")
+	}
+	oauthErr, ok := err.(*OAuthError)
+	if !ok {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "invalid_grant" {
+		t.Errorf("error code: got %q, want invalid_grant", oauthErr.ErrorCode)
+	}
+}
+
+func TestAuthenticate_FullLoopbackFlow(t *testing.T) {
+	as := newAuthServer()
+	defer as.Close()
+
+	// The fake browser opener plays the role of the authorization server redirecting
+	// back to the loopback listener with a code and the matching state.
+	opener := func(rawURL string) error {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return err
+		}
+		state := u.Query().Get("state")
+		cb, err := url.Parse(u.Query().Get("redirect_uri"))
+		if err != nil {
+			return err
+		}
+		cbq := cb.Query()
+		cbq.Set("code", "loopback-code")
+		cbq.Set("state", state)
+		cb.RawQuery = cbq.Encode()
+		go func() {
+			resp, err := http.Get(cb.String())
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	tok, err := Authenticate(context.Background(), as.URL, AuthenticateRequest{
+		ClientID: "public-client",
+		Scopes:   []string{"mcp:tools"},
+	}, WithAuthenticateHTTPClient(as.Client()), WithBrowserOpener(opener))
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if tok.AccessToken != "at" {
+		t.Errorf("access token: got %q, want at", tok.AccessToken)
+	}
+	if as.lastForm.Get("code") != "loopback-code" {
+		t.Errorf("exchanged code: got %q, want loopback-code", as.lastForm.Get("code"))
+	}
+}
+
+func TestAuthenticate_StateMismatchRejected(t *testing.T) {
+	as := newAuthServer()
+	defer as.Close()
+
+	opener := func(rawURL string) error {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return err
+		}
+		cb, _ := url.Parse(u.Query().Get("redirect_uri"))
+		cbq := cb.Query()
+		cbq.Set("code", "loopback-code")
+		cbq.Set("state", "the-wrong-state")
+		cb.RawQuery = cbq.Encode()
+		go func() {
+			resp, err := http.Get(cb.String())
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	_, err := Authenticate(context.Background(), as.URL, AuthenticateRequest{
+		ClientID: "public-client",
+	}, WithAuthenticateHTTPClient(as.Client()), WithBrowserOpener(opener))
+	if err == nil {
+		t.Fatal("expected an error when the callback state does not match")
+	}
+}
+
+func TestResolveIssuerFromChallenge(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resource":              srv.URL,
+			"authorization_servers": []string{"https://zone.keycard.cloud"},
+		})
+	})
+
+	header := `Bearer error="invalid_token", resource_metadata="` + srv.URL + `/.well-known/oauth-protected-resource"`
+	issuer, err := ResolveIssuerFromChallenge(context.Background(), header, srv.Client())
+	if err != nil {
+		t.Fatalf("ResolveIssuerFromChallenge: %v", err)
+	}
+	if issuer != "https://zone.keycard.cloud" {
+		t.Errorf("issuer: got %q, want https://zone.keycard.cloud", issuer)
+	}
+}
+
+func TestResolveIssuerFromChallenge_NoMetadata(t *testing.T) {
+	if _, err := ResolveIssuerFromChallenge(context.Background(), `Bearer error="invalid_token"`, nil); err == nil {
+		t.Error("expected an error when the challenge has no resource_metadata")
+	}
+}

--- a/oauth/example_test.go
+++ b/oauth/example_test.go
@@ -1,0 +1,34 @@
+package oauth_test
+
+import (
+	"fmt"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+// ExampleGenerateCodeChallenge derives an S256 PKCE challenge from a verifier
+// (RFC 7636 Appendix B vector).
+func ExampleGenerateCodeChallenge() {
+	challenge, err := oauth.GenerateCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk", oauth.PKCEMethodS256)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(challenge)
+	// Output: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+}
+
+// ExampleBuildAuthorizeURL builds an authorization-code request URL with PKCE.
+func ExampleBuildAuthorizeURL() {
+	url, err := oauth.BuildAuthorizeURL("https://zone.keycard.cloud/authorize", oauth.AuthorizeURLParams{
+		ClientID:      "my-client",
+		RedirectURI:   "http://127.0.0.1:8765/callback",
+		CodeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		Scopes:        []string{"openid"},
+		State:         "xyz",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(url)
+	// Output: https://zone.keycard.cloud/authorize?client_id=my-client&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&redirect_uri=http%3A%2F%2F127.0.0.1%3A8765%2Fcallback&response_type=code&scope=openid&state=xyz
+}

--- a/oauth/pkce.go
+++ b/oauth/pkce.go
@@ -1,0 +1,69 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+)
+
+// PKCE code challenge methods (RFC 7636 §4.3).
+const (
+	// PKCEMethodS256 derives the challenge as BASE64URL(SHA-256(verifier)).
+	PKCEMethodS256 = "S256"
+	// PKCEMethodPlain uses the verifier as the challenge. RFC-permitted but not recommended.
+	PKCEMethodPlain = "plain"
+)
+
+// defaultCodeVerifierBytes yields a 128-character base64url verifier, the maximum
+// length RFC 7636 §4.1 allows (96 bytes -> 128 base64url characters).
+const defaultCodeVerifierBytes = 96
+
+// PKCEPair is a PKCE code verifier and its derived challenge (RFC 7636).
+type PKCEPair struct {
+	CodeVerifier        string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// GenerateCodeVerifier returns a cryptographically random PKCE code verifier of 128
+// unreserved characters. The base64url alphabet is a subset of the RFC 7636 §4.1
+// unreserved set, so the result is a valid verifier.
+func GenerateCodeVerifier() (string, error) {
+	b := make([]byte, defaultCodeVerifierBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating code verifier: %w", err)
+	}
+	return Base64URLEncode(b), nil
+}
+
+// GenerateCodeChallenge derives the PKCE challenge from a verifier. For PKCEMethodS256
+// it returns BASE64URL(SHA-256(verifier)); for PKCEMethodPlain it returns the verifier
+// unchanged. Any other method is an error.
+func GenerateCodeChallenge(verifier, method string) (string, error) {
+	switch method {
+	case PKCEMethodS256:
+		sum := sha256.Sum256([]byte(verifier))
+		return Base64URLEncode(sum[:]), nil
+	case PKCEMethodPlain:
+		return verifier, nil
+	default:
+		return "", fmt.Errorf("unsupported PKCE method %q", method)
+	}
+}
+
+// GeneratePKCEPair generates a verifier and its S256 challenge.
+func GeneratePKCEPair() (PKCEPair, error) {
+	verifier, err := GenerateCodeVerifier()
+	if err != nil {
+		return PKCEPair{}, err
+	}
+	challenge, err := GenerateCodeChallenge(verifier, PKCEMethodS256)
+	if err != nil {
+		return PKCEPair{}, err
+	}
+	return PKCEPair{
+		CodeVerifier:        verifier,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: PKCEMethodS256,
+	}, nil
+}

--- a/oauth/pkce_test.go
+++ b/oauth/pkce_test.go
@@ -1,0 +1,74 @@
+package oauth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	const unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+
+	v, err := GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier: %v", err)
+	}
+	if len(v) < 43 || len(v) > 128 {
+		t.Errorf("verifier length %d outside RFC 7636 range 43-128", len(v))
+	}
+	for _, c := range v {
+		if !strings.ContainsRune(unreserved, c) {
+			t.Errorf("verifier contains non-unreserved character %q", c)
+		}
+	}
+
+	// Two verifiers should differ.
+	v2, _ := GenerateCodeVerifier()
+	if v == v2 {
+		t.Error("two generated verifiers were identical")
+	}
+}
+
+func TestGenerateCodeChallenge_S256(t *testing.T) {
+	// RFC 7636 Appendix B known-answer vector.
+	const (
+		verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+		challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	)
+	got, err := GenerateCodeChallenge(verifier, PKCEMethodS256)
+	if err != nil {
+		t.Fatalf("GenerateCodeChallenge: %v", err)
+	}
+	if got != challenge {
+		t.Errorf("S256 challenge: got %q, want %q", got, challenge)
+	}
+}
+
+func TestGenerateCodeChallenge_Plain(t *testing.T) {
+	got, err := GenerateCodeChallenge("verifier-value", PKCEMethodPlain)
+	if err != nil {
+		t.Fatalf("GenerateCodeChallenge: %v", err)
+	}
+	if got != "verifier-value" {
+		t.Errorf("plain challenge: got %q, want the verifier unchanged", got)
+	}
+}
+
+func TestGenerateCodeChallenge_Unsupported(t *testing.T) {
+	if _, err := GenerateCodeChallenge("v", "RS256"); err == nil {
+		t.Error("expected error for an unsupported PKCE method")
+	}
+}
+
+func TestGeneratePKCEPair(t *testing.T) {
+	pair, err := GeneratePKCEPair()
+	if err != nil {
+		t.Fatalf("GeneratePKCEPair: %v", err)
+	}
+	if pair.CodeChallengeMethod != PKCEMethodS256 {
+		t.Errorf("method: got %q, want S256", pair.CodeChallengeMethod)
+	}
+	want, _ := GenerateCodeChallenge(pair.CodeVerifier, PKCEMethodS256)
+	if pair.CodeChallenge != want {
+		t.Errorf("challenge does not match S256(verifier): got %q, want %q", pair.CodeChallenge, want)
+	}
+}


### PR DESCRIPTION
## What

Implements the [authorization-code-pkce](https://github.com/keycardai/keycard-sdk-spec/blob/main/specs/oauth-client/authorization-code-pkce.md) spec in the `oauth` package — the user-facing login primitive the Go SDK was missing entirely. Part of the Go SDK parity effort (M3).

## Layers

- **PKCE primitives:** `GenerateCodeVerifier` (128-char, RFC 7636 §4.1), `GenerateCodeChallenge` (S256 / plain), `GeneratePKCEPair`.
- **Building blocks:** `BuildAuthorizeURL` (response_type=code + PKCE params) and `ExchangeAuthorizationCode` — public client sends `client_id` in the body; confidential client uses HTTP Basic and omits it. Reuses discovery and the shared token-response shape.
- **High-level flow:** `Authenticate` / `AuthenticateFromChallenge` generate a PKCE pair and CSRF state, open the browser, run an RFC 8252 loopback server (default port 8765, 300s timeout), validate state, and exchange the code. `ResolveIssuerFromChallenge` resolves the issuer from an RFC 9728 `WWW-Authenticate` challenge. Browser launch uses `exec.Command` (no shell) and is overridable for tests.

## Tests

PKCE primitives (incl. the RFC 7636 Appendix B known-answer vector), the authorize-URL builder, public/confidential code exchange, OAuth error responses, the full loopback flow in-process via an injected browser opener, CSRF state-mismatch rejection, and challenge-driven issuer resolution. `go vet`, `go test -race`, `go build ./examples/...`, gofmt all clean.

## Notes

- `token_type` casing and the `id_token` field follow the current shared `deserializeTokenResponse`; both are slated for the Phase 4 token-exchange alignment across all consumers.
- New `oauth` capability, no existing PR/branch overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
