### PR TITLE
feat: add dynamic client registration (RFC 7591) (ECO-91)

### DIFF
--- a/examples/dynamic-client-registration/main.go
+++ b/examples/dynamic-client-registration/main.go
@@ -1,0 +1,53 @@
+// Package main demonstrates dynamic client registration (RFC 7591): it registers a
+// new OAuth client with a zone and prints the issued client_id.
+//
+// Configure in Keycard before running:
+//   - A zone (KEYCARD_ZONE_URL) whose authorization server advertises a
+//     registration_endpoint.
+//   - Optionally KEYCARD_INITIAL_ACCESS_TOKEN, if the zone requires the registration
+//     request to be authenticated.
+//
+// Run:
+//
+//	KEYCARD_ZONE_URL=... go run ./examples/dynamic-client-registration
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+func main() {
+	zoneURL := os.Getenv("KEYCARD_ZONE_URL")
+	if zoneURL == "" {
+		log.Fatal("KEYCARD_ZONE_URL environment variable is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var opts []oauth.RegisterOption
+	if iat := os.Getenv("KEYCARD_INITIAL_ACCESS_TOKEN"); iat != "" {
+		opts = append(opts, oauth.WithInitialAccessToken(iat))
+	}
+
+	resp, err := oauth.RegisterClient(ctx, zoneURL, oauth.RegistrationRequest{
+		ClientName:              "credentials-go example",
+		RedirectURIs:            []string{"http://127.0.0.1:8765/callback"},
+		GrantTypes:              []string{"authorization_code"},
+		TokenEndpointAuthMethod: "none",
+	}, opts...)
+	if err != nil {
+		log.Fatalf("registration failed: %v", err)
+	}
+
+	fmt.Printf("Registered client_id: %s\n", resp.ClientID)
+	if resp.ClientSecret != "" {
+		fmt.Println("A client_secret was issued (confidential client).")
+	}
+}

--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -1,0 +1,198 @@
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// RegistrationRequest is RFC 7591 §2 client metadata. Every field is optional; only the
+// fields the caller sets are sent (the authorization server defaults the rest).
+// AdditionalMetadata carries vendor or AS-specific keys and is merged into the request
+// body, with the named fields below taking precedence on conflict.
+type RegistrationRequest struct {
+	ClientName              string
+	RedirectURIs            []string
+	GrantTypes              []string
+	ResponseTypes           []string
+	Scope                   string
+	TokenEndpointAuthMethod string
+	JWKSURI                 string
+	JWKS                    map[string]any
+	ClientURI               string
+	LogoURI                 string
+	TosURI                  string
+	PolicyURI               string
+	SoftwareID              string
+	SoftwareVersion         string
+	AdditionalMetadata      map[string]any
+}
+
+// RegistrationResponse is RFC 7591 §3.2.1. Raw preserves the full response body so
+// AS-specific fields not modeled here remain accessible.
+type RegistrationResponse struct {
+	ClientID                string
+	ClientSecret            string
+	ClientIDIssuedAt        int64
+	ClientSecretExpiresAt   int64
+	RegistrationAccessToken string
+	RegistrationClientURI   string
+	Raw                     map[string]any
+}
+
+// RegisterOption configures RegisterClient.
+type RegisterOption func(*registrationConfig)
+
+type registrationConfig struct {
+	httpClient         *http.Client
+	initialAccessToken string
+}
+
+// WithRegistrationHTTPClient sets the HTTP client used for discovery and registration.
+func WithRegistrationHTTPClient(c *http.Client) RegisterOption {
+	return func(cfg *registrationConfig) { cfg.httpClient = c }
+}
+
+// WithInitialAccessToken authenticates the registration request with a Bearer initial
+// access token (RFC 7591 §3.1), for authorization servers that require one.
+func WithInitialAccessToken(token string) RegisterOption {
+	return func(cfg *registrationConfig) { cfg.initialAccessToken = token }
+}
+
+// RegisterClient registers a new OAuth client at the issuer's registration endpoint
+// (resolved by discovery) and returns the issued credentials (RFC 7591).
+func RegisterClient(ctx context.Context, issuer string, req RegistrationRequest, opts ...RegisterOption) (*RegistrationResponse, error) {
+	cfg := registrationConfig{httpClient: http.DefaultClient}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	metadata, err := FetchAuthorizationServerMetadata(ctx, issuer, WithDiscoveryHTTPClient(cfg.httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("discovering registration endpoint: %w", err)
+	}
+	if metadata.RegistrationEndpoint == "" {
+		return nil, fmt.Errorf("authorization server %q does not advertise a registration_endpoint", issuer)
+	}
+
+	payload, err := json.Marshal(registrationBody(req))
+	if err != nil {
+		return nil, fmt.Errorf("encoding registration request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, metadata.RegistrationEndpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("creating registration request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	if cfg.initialAccessToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+cfg.initialAccessToken)
+	}
+
+	resp, err := cfg.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("registration request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// RFC 7591 §3.2.1 returns 201 Created; some servers return 200.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		var errBody map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
+			if errCode, ok := errBody["error"].(string); ok {
+				oauthErr := &OAuthError{ErrorCode: errCode, Message: errCode}
+				if desc, ok := errBody["error_description"].(string); ok {
+					oauthErr.Message = desc
+				}
+				if uri, ok := errBody["error_uri"].(string); ok {
+					oauthErr.ErrorURI = uri
+				}
+				return nil, oauthErr
+			}
+		}
+		return nil, &HTTPError{Message: "client registration failed", Status: resp.StatusCode}
+	}
+
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decoding registration response: %w", err)
+	}
+
+	clientID, _ := raw["client_id"].(string)
+	if clientID == "" {
+		return nil, fmt.Errorf("registration response missing client_id")
+	}
+
+	result := &RegistrationResponse{ClientID: clientID, Raw: raw}
+	if v, ok := raw["client_secret"].(string); ok {
+		result.ClientSecret = v
+	}
+	if v, ok := raw["client_id_issued_at"].(float64); ok {
+		result.ClientIDIssuedAt = int64(v)
+	}
+	if v, ok := raw["client_secret_expires_at"].(float64); ok {
+		result.ClientSecretExpiresAt = int64(v)
+	}
+	if v, ok := raw["registration_access_token"].(string); ok {
+		result.RegistrationAccessToken = v
+	}
+	if v, ok := raw["registration_client_uri"].(string); ok {
+		result.RegistrationClientURI = v
+	}
+	return result, nil
+}
+
+// registrationBody merges AdditionalMetadata with the named fields, with the named
+// fields winning on conflict, and omits fields the caller left unset (RFC-minimal).
+func registrationBody(req RegistrationRequest) map[string]any {
+	body := map[string]any{}
+	for k, v := range req.AdditionalMetadata {
+		body[k] = v
+	}
+	if req.ClientName != "" {
+		body["client_name"] = req.ClientName
+	}
+	if len(req.RedirectURIs) > 0 {
+		body["redirect_uris"] = req.RedirectURIs
+	}
+	if len(req.GrantTypes) > 0 {
+		body["grant_types"] = req.GrantTypes
+	}
+	if len(req.ResponseTypes) > 0 {
+		body["response_types"] = req.ResponseTypes
+	}
+	if req.Scope != "" {
+		body["scope"] = req.Scope
+	}
+	if req.TokenEndpointAuthMethod != "" {
+		body["token_endpoint_auth_method"] = req.TokenEndpointAuthMethod
+	}
+	if req.JWKSURI != "" {
+		body["jwks_uri"] = req.JWKSURI
+	}
+	if req.JWKS != nil {
+		body["jwks"] = req.JWKS
+	}
+	if req.ClientURI != "" {
+		body["client_uri"] = req.ClientURI
+	}
+	if req.LogoURI != "" {
+		body["logo_uri"] = req.LogoURI
+	}
+	if req.TosURI != "" {
+		body["tos_uri"] = req.TosURI
+	}
+	if req.PolicyURI != "" {
+		body["policy_uri"] = req.PolicyURI
+	}
+	if req.SoftwareID != "" {
+		body["software_id"] = req.SoftwareID
+	}
+	if req.SoftwareVersion != "" {
+		body["software_version"] = req.SoftwareVersion
+	}
+	return body
+}

--- a/oauth/registration_test.go
+++ b/oauth/registration_test.go
@@ -1,0 +1,153 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// registrationServer serves discovery metadata advertising its own /register endpoint
+// and records the registration request it receives.
+type registrationServer struct {
+	*httptest.Server
+	lastBody  map[string]any
+	lastAuth  string
+	regStatus int
+	regBody   string
+}
+
+func newRegistrationServer() *registrationServer {
+	rs := &registrationServer{
+		regStatus: http.StatusCreated,
+		regBody:   `{"client_id":"generated-id","client_secret":"generated-secret","client_id_issued_at":1700000000,"client_secret_expires_at":0,"registration_access_token":"rat","registration_client_uri":"https://zone/register/generated-id"}`,
+	}
+	mux := http.NewServeMux()
+	rs.Server = httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                rs.URL,
+			"registration_endpoint": rs.URL + "/register",
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		rs.lastAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&rs.lastBody)
+		w.WriteHeader(rs.regStatus)
+		_, _ = w.Write([]byte(rs.regBody))
+	})
+	return rs
+}
+
+func TestRegisterClient_BodyMergesNamedFieldsOverVendorKeys(t *testing.T) {
+	rs := newRegistrationServer()
+	defer rs.Close()
+
+	_, err := RegisterClient(context.Background(), rs.URL, RegistrationRequest{
+		ClientName:              "My Tool",
+		RedirectURIs:            []string{"http://127.0.0.1:8765/callback"},
+		TokenEndpointAuthMethod: "none",
+		AdditionalMetadata: map[string]any{
+			"software_statement": "vendor-value",
+			"client_name":        "should-be-overridden",
+		},
+	}, WithRegistrationHTTPClient(rs.Client()))
+	if err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	if rs.lastBody["client_name"] != "My Tool" {
+		t.Errorf("named client_name should win over vendor key, got %v", rs.lastBody["client_name"])
+	}
+	if rs.lastBody["software_statement"] != "vendor-value" {
+		t.Errorf("vendor key should be merged into the body, got %v", rs.lastBody["software_statement"])
+	}
+	if rs.lastBody["token_endpoint_auth_method"] != "none" {
+		t.Errorf("token_endpoint_auth_method: got %v", rs.lastBody["token_endpoint_auth_method"])
+	}
+	if _, ok := rs.lastBody["scope"]; ok {
+		t.Error("unset fields should be omitted (RFC-minimal)")
+	}
+}
+
+func TestRegisterClient_ParsesResponse(t *testing.T) {
+	rs := newRegistrationServer()
+	defer rs.Close()
+
+	resp, err := RegisterClient(context.Background(), rs.URL, RegistrationRequest{
+		ClientName: "My Tool",
+	}, WithRegistrationHTTPClient(rs.Client()))
+	if err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	if resp.ClientID != "generated-id" {
+		t.Errorf("client_id: got %q", resp.ClientID)
+	}
+	if resp.ClientSecret != "generated-secret" {
+		t.Errorf("client_secret: got %q", resp.ClientSecret)
+	}
+	if resp.ClientIDIssuedAt != 1700000000 {
+		t.Errorf("client_id_issued_at: got %d", resp.ClientIDIssuedAt)
+	}
+	if resp.ClientSecretExpiresAt != 0 {
+		t.Errorf("client_secret_expires_at: got %d", resp.ClientSecretExpiresAt)
+	}
+	if resp.RegistrationAccessToken != "rat" {
+		t.Errorf("registration_access_token: got %q", resp.RegistrationAccessToken)
+	}
+	if resp.RegistrationClientURI != "https://zone/register/generated-id" {
+		t.Errorf("registration_client_uri: got %q", resp.RegistrationClientURI)
+	}
+	if resp.Raw["client_id"] != "generated-id" {
+		t.Error("raw body should be preserved")
+	}
+}
+
+func TestRegisterClient_MissingClientID(t *testing.T) {
+	rs := newRegistrationServer()
+	defer rs.Close()
+	rs.regBody = `{"client_secret":"secret-without-id"}`
+
+	_, err := RegisterClient(context.Background(), rs.URL, RegistrationRequest{}, WithRegistrationHTTPClient(rs.Client()))
+	if err == nil {
+		t.Fatal("expected an error when the response has no client_id")
+	}
+}
+
+func TestRegisterClient_OAuthError(t *testing.T) {
+	rs := newRegistrationServer()
+	defer rs.Close()
+	rs.regStatus = http.StatusBadRequest
+	rs.regBody = `{"error":"invalid_client_metadata","error_description":"bad redirect_uri"}`
+
+	_, err := RegisterClient(context.Background(), rs.URL, RegistrationRequest{
+		RedirectURIs: []string{"not-a-uri"},
+	}, WithRegistrationHTTPClient(rs.Client()))
+	if err == nil {
+		t.Fatal("expected an error for the OAuth error response")
+	}
+	oauthErr, ok := err.(*OAuthError)
+	if !ok {
+		t.Fatalf("expected *OAuthError, got %T: %v", err, err)
+	}
+	if oauthErr.ErrorCode != "invalid_client_metadata" {
+		t.Errorf("error code: got %q, want invalid_client_metadata", oauthErr.ErrorCode)
+	}
+}
+
+func TestRegisterClient_InitialAccessToken(t *testing.T) {
+	rs := newRegistrationServer()
+	defer rs.Close()
+
+	_, err := RegisterClient(context.Background(), rs.URL, RegistrationRequest{
+		ClientName: "My Tool",
+	}, WithRegistrationHTTPClient(rs.Client()), WithInitialAccessToken("iat-123"))
+	if err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+	if rs.lastAuth != "Bearer iat-123" {
+		t.Errorf("Authorization header: got %q, want Bearer iat-123", rs.lastAuth)
+	}
+}


### PR DESCRIPTION
## What

Implements the [dynamic-client-registration](https://github.com/keycardai/keycard-sdk-spec/blob/main/specs/oauth-client/dynamic-client-registration.md) spec (RFC 7591) in the `oauth` package. Discovery already parsed `registration_endpoint`; this adds the call that POSTs to it. Part of the Go SDK parity effort (M3).

## Changes

- `RegisterClient(ctx, issuer, req, opts...)` discovers the registration endpoint and POSTs the client metadata as JSON.
- `RegistrationRequest` models the RFC 7591 §2 metadata (all optional, RFC-minimal: only set fields are sent) with an `AdditionalMetadata` bag merged into the body; named fields win on conflict.
- `RegistrationResponse` parses `client_id` (required), `client_secret`, issuance/expiry timestamps, and the registration management token/URI, preserving the full raw body for AS-specific fields.
- `WithInitialAccessToken` authenticates the request with a Bearer initial access token (RFC 7591 §3.1). A structured 4xx error body surfaces as a typed `*OAuthError`, otherwise an `*HTTPError`.

## Tests

Body merging (named over vendor keys, RFC-minimal omission), response parsing, the missing-`client_id` error, the typed OAuth error, and the initial-access-token header. `go vet`, `go test -race`, gofmt all clean.

## Notes

The RFC 7591 error-body parsing is inlined here to keep this branch independent of the PKCE branch; the Phase 4 token-exchange/base-error work will unify the OAuth-error-from-response helper across token-exchange, client-credentials, auth-code, and this. New `oauth` capability, no existing PR/branch overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
