### PR TITLE
feat!: add multi-zone support to the auth provider (ECO-93)

### DIFF
--- a/examples/multi-zone/main.go
+++ b/examples/multi-zone/main.go
@@ -1,0 +1,82 @@
+// Package main demonstrates multi-zone support: one server that verifies and exchanges
+// tokens for several Keycard zones, routing each request by the token's issuer.
+//
+// Configure in Keycard before running:
+//   - Two zones, each with a confidential client:
+//     KEYCARD_ZONE_A_URL / KEYCARD_ZONE_A_CLIENT_ID / KEYCARD_ZONE_A_CLIENT_SECRET
+//     KEYCARD_ZONE_B_URL / KEYCARD_ZONE_B_CLIENT_ID / KEYCARD_ZONE_B_CLIENT_SECRET
+//   - A downstream resource to exchange for (KEYCARD_RESOURCE).
+//
+// Run:
+//
+//	KEYCARD_ZONE_A_URL=... KEYCARD_ZONE_B_URL=... KEYCARD_RESOURCE=... \
+//	KEYCARD_ZONE_A_CLIENT_ID=... KEYCARD_ZONE_A_CLIENT_SECRET=... \
+//	KEYCARD_ZONE_B_CLIENT_ID=... KEYCARD_ZONE_B_CLIENT_SECRET=... go run ./examples/multi-zone
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/keycardai/credentials-go/mcp"
+)
+
+func main() {
+	aURL := os.Getenv("KEYCARD_ZONE_A_URL")
+	bURL := os.Getenv("KEYCARD_ZONE_B_URL")
+	resource := os.Getenv("KEYCARD_RESOURCE")
+	if aURL == "" || bURL == "" || resource == "" {
+		log.Fatal("KEYCARD_ZONE_A_URL, KEYCARD_ZONE_B_URL, and KEYCARD_RESOURCE are required")
+	}
+
+	// One credential carrying both zones' client credentials, keyed by zone URL. It is
+	// self-describing: holding more than one zone makes the provider multi-zone.
+	credential := mcp.NewMultiZoneClientSecret(map[string]mcp.ClientAuth{
+		aURL: {ClientID: os.Getenv("KEYCARD_ZONE_A_CLIENT_ID"), ClientSecret: os.Getenv("KEYCARD_ZONE_A_CLIENT_SECRET")},
+		bURL: {ClientID: os.Getenv("KEYCARD_ZONE_B_CLIENT_ID"), ClientSecret: os.Getenv("KEYCARD_ZONE_B_CLIENT_SECRET")},
+	})
+
+	// The verifier trusts tokens from either zone; the token's iss selects the zone and
+	// its JWKS. A token from any other issuer is rejected.
+	verifier, err := mcp.NewMultiZoneTokenVerifier([]string{aURL, bURL})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	provider, err := mcp.NewAuthProvider(mcp.WithApplicationCredential(credential))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Grant routes the exchange to whichever zone minted the request's token.
+	handler := mcp.RequireBearerAuth(verifier)(
+		provider.Grant(resource)(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				info := mcp.AuthInfoFromRequest(r)
+				ac := mcp.AccessContextFromRequest(r)
+				token, err := ac.Access(resource)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadGateway)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"zone":  info.Issuer,
+					"token": token.AccessToken,
+				})
+			}),
+		),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/resource", handler)
+
+	addr := ":8080"
+	if port := os.Getenv("PORT"); port != "" {
+		addr = ":" + port
+	}
+	log.Printf("Multi-zone server listening on %s (zones: %s, %s)", addr, aURL, bURL)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -25,28 +25,69 @@ type PrepareOptions struct {
 
 // ApplicationCredential authenticates the MCP server during token exchange.
 type ApplicationCredential interface {
-	// Auth returns client credentials for HTTP basic auth, or nil for assertion-based auth.
-	Auth() *ClientAuth
+	// Auth returns client credentials for HTTP basic auth for the given zone issuer, or
+	// nil for assertion-based auth or an unknown zone. Single-zone credentials ignore
+	// the issuer.
+	Auth(issuer string) *ClientAuth
 
 	// PrepareTokenExchangeRequest builds a token exchange request with any needed
 	// client authentication (assertions, etc.).
 	PrepareTokenExchangeRequest(ctx context.Context, subjectToken, resource string, opts *PrepareOptions) (*oauth.TokenExchangeRequest, error)
 }
 
-// ClientSecretCredential implements ApplicationCredential using client_id/client_secret basic auth.
+// MultiZoneCredential is implemented by credentials that carry per-zone client
+// credentials keyed by zone issuer URL. A provider uses Zones to discover the zone set
+// and switch into multi-zone routing. Single-zone credentials report no zones.
+type MultiZoneCredential interface {
+	// Zones returns the configured zone issuer URLs (empty for a single-zone credential).
+	Zones() []string
+}
+
+// ClientSecretCredential implements ApplicationCredential using client_id/client_secret
+// basic auth. It is single-zone by default; NewMultiZoneClientSecret makes it carry
+// per-zone credentials keyed by zone issuer URL.
 type ClientSecretCredential struct {
 	clientID     string
 	clientSecret string
+	zones        map[string]ClientAuth // non-nil only for a multi-zone credential
 }
 
-// NewClientSecret creates a new ClientSecretCredential.
+// NewClientSecret creates a single-zone ClientSecretCredential.
 func NewClientSecret(clientID, clientSecret string) *ClientSecretCredential {
 	return &ClientSecretCredential{clientID: clientID, clientSecret: clientSecret}
 }
 
-// Auth returns the client credentials for basic auth.
-func (c *ClientSecretCredential) Auth() *ClientAuth {
+// NewMultiZoneClientSecret creates a multi-zone ClientSecretCredential from a map of
+// zone issuer URL to that zone's client credentials. The credential is self-describing:
+// holding zone entries marks it multi-zone.
+func NewMultiZoneClientSecret(zones map[string]ClientAuth) *ClientSecretCredential {
+	return &ClientSecretCredential{zones: zones}
+}
+
+// Auth returns the basic-auth credentials for the given zone issuer. A single-zone
+// credential returns its one credential for any issuer; a multi-zone credential returns
+// the matching zone's credential, or nil if the zone is unknown (fail-closed).
+func (c *ClientSecretCredential) Auth(issuer string) *ClientAuth {
+	if c.zones != nil {
+		if a, ok := c.zones[issuer]; ok {
+			return &a
+		}
+		return nil
+	}
 	return &ClientAuth{ClientID: c.clientID, ClientSecret: c.clientSecret}
+}
+
+// Zones returns the configured zone issuer URLs (nil for a single-zone credential),
+// implementing MultiZoneCredential.
+func (c *ClientSecretCredential) Zones() []string {
+	if c.zones == nil {
+		return nil
+	}
+	zones := make([]string, 0, len(c.zones))
+	for issuer := range c.zones {
+		zones = append(zones, issuer)
+	}
+	return zones
 }
 
 // PrepareTokenExchangeRequest builds a basic token exchange request.
@@ -134,7 +175,7 @@ func (w *WebIdentityCredential) Bootstrap() error {
 }
 
 // Auth returns nil (WebIdentity uses assertion-based auth, not basic auth).
-func (w *WebIdentityCredential) Auth() *ClientAuth {
+func (w *WebIdentityCredential) Auth(_ string) *ClientAuth {
 	return nil
 }
 
@@ -257,7 +298,7 @@ func NewEKSWorkloadIdentity(opts ...EKSWorkloadIdentityOption) (*EKSWorkloadIden
 }
 
 // Auth returns nil (EKS uses assertion-based auth, not basic auth).
-func (e *EKSWorkloadIdentityCredential) Auth() *ClientAuth {
+func (e *EKSWorkloadIdentityCredential) Auth(_ string) *ClientAuth {
 	return nil
 }
 

--- a/mcp/multizone_test.go
+++ b/mcp/multizone_test.go
@@ -1,0 +1,247 @@
+package mcp
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+// zoneServer is a fake authorization server for one zone: it serves discovery and a
+// /token endpoint that records the Basic-auth client id it received, so tests can
+// assert that the exchange used the right zone's credential.
+type zoneServer struct {
+	*httptest.Server
+	mu           sync.Mutex
+	lastClientID string
+}
+
+func newZoneServer(t *testing.T) *zoneServer {
+	t.Helper()
+	zs := &zoneServer{}
+	mux := http.NewServeMux()
+	zs.Server = httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":         zs.URL,
+			"token_endpoint": zs.URL + "/token",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		id, _, _ := r.BasicAuth()
+		zs.mu.Lock()
+		zs.lastClientID = id
+		zs.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok-from-" + zs.URL, "token_type": "Bearer"})
+	})
+	t.Cleanup(zs.Close)
+	return zs
+}
+
+func (zs *zoneServer) clientID() string {
+	zs.mu.Lock()
+	defer zs.mu.Unlock()
+	return zs.lastClientID
+}
+
+// multiZoneKeyring resolves a verification key per issuer, so a zone-A token can only be
+// verified with zone A's key.
+type multiZoneKeyring struct {
+	keys map[string]crypto.PublicKey
+}
+
+func (k *multiZoneKeyring) Key(_ context.Context, issuer, _ string) (crypto.PublicKey, error) {
+	if pub, ok := k.keys[issuer]; ok {
+		return pub, nil
+	}
+	return nil, fmt.Errorf("no key for issuer %q", issuer)
+}
+
+// issuerSignKeyring mints tokens for a single issuer.
+type issuerSignKeyring struct {
+	key    *rsa.PrivateKey
+	issuer string
+}
+
+func (s *issuerSignKeyring) Key(_ context.Context, _ string) (oauth.IdentifiableKey, error) {
+	return oauth.IdentifiableKey{Key: s.key, Issuer: s.issuer, KID: "kid"}, nil
+}
+
+func mintZoneToken(t *testing.T, key *rsa.PrivateKey, issuer string) string {
+	t.Helper()
+	signer := oauth.NewJWTSigner(&issuerSignKeyring{key: key, issuer: issuer})
+	now := time.Now().Unix()
+	token, err := signer.Sign(context.Background(), oauth.JWTClaims{
+		Subject:  "user-1",
+		ClientID: "user-client",
+		Audience: []string{"https://mcp.example.com"},
+		IssuedAt: now,
+		Expiry:   now + 3600,
+	})
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+	return token
+}
+
+func serveWithToken(h http.Handler, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", "/api", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// Spec row 1: a multi-zone credential is self-describing and resolves per zone.
+func TestMultiZoneClientSecret_ResolvesPerZone(t *testing.T) {
+	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+		"https://zone-a.keycard.cloud": {ClientID: "client-a", ClientSecret: "secret-a"},
+		"https://zone-b.keycard.cloud": {ClientID: "client-b", ClientSecret: "secret-b"},
+	})
+
+	if len(cred.Zones()) != 2 {
+		t.Errorf("Zones: got %d, want 2", len(cred.Zones()))
+	}
+	if a := cred.Auth("https://zone-a.keycard.cloud"); a == nil || a.ClientID != "client-a" {
+		t.Errorf("zone A auth: got %+v, want client-a", a)
+	}
+	if b := cred.Auth("https://zone-b.keycard.cloud"); b == nil || b.ClientID != "client-b" {
+		t.Errorf("zone B auth: got %+v, want client-b", b)
+	}
+	if cred.Auth("https://zone-c.keycard.cloud") != nil {
+		t.Error("unknown zone should resolve to nil (fail-closed)")
+	}
+}
+
+// Spec rows 3 + 6: the exchange routes to the resolved zone's credential, and
+// interleaved zones do not leak each other's credentials.
+func TestAuthProvider_ExchangeRoutesToZoneCredential(t *testing.T) {
+	zoneA := newZoneServer(t)
+	zoneB := newZoneServer(t)
+
+	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+		zoneA.URL: {ClientID: "client-a", ClientSecret: "secret-a"},
+		zoneB.URL: {ClientID: "client-b", ClientSecret: "secret-b"},
+	})
+	provider, err := NewAuthProvider(WithApplicationCredential(cred))
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+
+	acA := provider.ExchangeTokensForZone(context.Background(), zoneA.URL, "user-token", "https://api.example.com")
+	if acA.HasErrors() {
+		_, ge := acA.GetErrors()
+		t.Fatalf("zone A exchange failed: %+v", ge)
+	}
+	if zoneA.clientID() != "client-a" {
+		t.Errorf("zone A exchange used client %q, want client-a", zoneA.clientID())
+	}
+
+	acB := provider.ExchangeTokensForZone(context.Background(), zoneB.URL, "user-token", "https://api.example.com")
+	if acB.HasErrors() {
+		t.Fatal("zone B exchange failed")
+	}
+	if zoneB.clientID() != "client-b" {
+		t.Errorf("zone B exchange used client %q, want client-b", zoneB.clientID())
+	}
+	// No leakage: zone A's endpoint never saw zone B's credential.
+	if zoneA.clientID() != "client-a" {
+		t.Errorf("zone A client changed to %q after a zone B exchange", zoneA.clientID())
+	}
+}
+
+// Spec row 5: a resolved zone with no configured credential fails closed.
+func TestAuthProvider_MultiZoneUnknownZoneFailsClosed(t *testing.T) {
+	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+		"https://zone-a.keycard.cloud": {ClientID: "client-a", ClientSecret: "secret-a"},
+	})
+	provider, err := NewAuthProvider(WithApplicationCredential(cred))
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+
+	ac := provider.ExchangeTokensForZone(context.Background(), "https://zone-unknown.keycard.cloud", "user-token", "https://api.example.com")
+	if !ac.HasError() {
+		t.Fatal("expected a fail-closed global error for an unconfigured zone")
+	}
+}
+
+// Spec row 4: a request whose zone cannot be resolved fails closed.
+func TestAuthProvider_MultiZoneUnresolvedZoneFailsClosed(t *testing.T) {
+	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+		"https://zone-a.keycard.cloud": {ClientID: "client-a", ClientSecret: "secret-a"},
+	})
+	provider, err := NewAuthProvider(WithApplicationCredential(cred))
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+
+	// ExchangeTokens carries no issuer; a multi-zone provider cannot resolve a zone.
+	ac := provider.ExchangeTokens(context.Background(), "user-token", "https://api.example.com")
+	if !ac.HasError() {
+		t.Fatal("expected a fail-closed global error when the zone is unresolved")
+	}
+}
+
+// Spec rows 2 + 3 end to end: a request's token issuer selects the zone for both
+// verification and the outbound exchange.
+func TestAuthProvider_GrantRoutesByTokenIssuer(t *testing.T) {
+	zoneA := newZoneServer(t)
+	zoneB := newZoneServer(t)
+	keyA, _ := rsa.GenerateKey(rand.Reader, 2048)
+	keyB, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	verifier, err := NewJWTOAuthTokenVerifier(
+		&multiZoneKeyring{keys: map[string]crypto.PublicKey{zoneA.URL: &keyA.PublicKey, zoneB.URL: &keyB.PublicKey}},
+		[]string{zoneA.URL, zoneB.URL},
+	)
+	if err != nil {
+		t.Fatalf("NewJWTOAuthTokenVerifier: %v", err)
+	}
+
+	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+		zoneA.URL: {ClientID: "client-a", ClientSecret: "secret-a"},
+		zoneB.URL: {ClientID: "client-b", ClientSecret: "secret-b"},
+	})
+	provider, err := NewAuthProvider(WithApplicationCredential(cred))
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+
+	handler := RequireBearerAuth(verifier)(
+		provider.Grant("https://api.example.com")(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ac := AccessContextFromRequest(r)
+				if _, err := ac.Access("https://api.example.com"); err != nil {
+					http.Error(w, err.Error(), http.StatusBadGateway)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}),
+		),
+	)
+
+	if rec := serveWithToken(handler, mintZoneToken(t, keyA, zoneA.URL)); rec.Code != http.StatusOK {
+		t.Fatalf("zone A request: status %d, body %q", rec.Code, rec.Body.String())
+	}
+	if zoneA.clientID() != "client-a" {
+		t.Errorf("zone A token routed to client %q, want client-a", zoneA.clientID())
+	}
+
+	if rec := serveWithToken(handler, mintZoneToken(t, keyB, zoneB.URL)); rec.Code != http.StatusOK {
+		t.Fatalf("zone B request: status %d, body %q", rec.Code, rec.Body.String())
+	}
+	if zoneB.clientID() != "client-b" {
+		t.Errorf("zone B token routed to client %q, want client-b", zoneB.clientID())
+	}
+}

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -187,18 +187,23 @@ func WithProviderHTTPClient(c *http.Client) AuthProviderOption {
 	return func(cfg *authProviderConfig) { cfg.httpClient = c }
 }
 
-// AuthProvider orchestrates token exchange for MCP servers.
+// AuthProvider orchestrates token exchange for MCP servers. It is single-zone unless
+// constructed with a multi-zone credential (NewMultiZoneClientSecret), in which case it
+// routes each exchange to the zone that minted the request's token.
 type AuthProvider struct {
-	zoneURL    string
-	credential ApplicationCredential
-	httpClient *http.Client
+	multiZone   bool
+	defaultZone string          // single-zone issuer URL ("" when multi-zone)
+	zones       map[string]bool // configured zone issuer URLs
+	credential  ApplicationCredential
+	httpClient  *http.Client
 
-	clientOnce sync.Once
-	client     *oauth.TokenExchangeClient
-	clientErr  error
+	mu      sync.Mutex
+	clients map[string]*oauth.TokenExchangeClient // per-zone, lazily created
 }
 
-// NewAuthProvider creates a new AuthProvider with the given options.
+// NewAuthProvider creates a new AuthProvider with the given options. With a multi-zone
+// credential the zones are taken from the credential and zoneURL/zoneID are not required;
+// otherwise exactly one zone is configured from zoneURL or zoneID.
 func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 	cfg := authProviderConfig{
 		baseURL:    "https://keycard.cloud",
@@ -208,21 +213,34 @@ func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 		opt(&cfg)
 	}
 
+	p := &AuthProvider{
+		credential: cfg.applicationCredential,
+		httpClient: cfg.httpClient,
+		zones:      make(map[string]bool),
+		clients:    make(map[string]*oauth.TokenExchangeClient),
+	}
+
+	// A multi-zone credential is self-describing: it carries the zone set.
+	if mz, ok := cfg.applicationCredential.(MultiZoneCredential); ok && len(mz.Zones()) > 0 {
+		p.multiZone = true
+		for _, zone := range mz.Zones() {
+			p.zones[zone] = true
+		}
+		return p, nil
+	}
+
 	zoneURL := cfg.zoneURL
 	if zoneURL == "" {
 		zoneURL = buildZoneURL(cfg.zoneID, cfg.baseURL)
 	}
 	if zoneURL == "" {
 		return nil, &AuthProviderConfigurationError{
-			Message: "either zoneURL or zoneID must be provided",
+			Message: "either zoneURL or zoneID must be provided (or a multi-zone credential)",
 		}
 	}
-
-	return &AuthProvider{
-		zoneURL:    zoneURL,
-		credential: cfg.applicationCredential,
-		httpClient: cfg.httpClient,
-	}, nil
+	p.defaultZone = zoneURL
+	p.zones[zoneURL] = true
+	return p, nil
 }
 
 // Grant returns middleware that performs token exchange for the specified resources.
@@ -242,26 +260,39 @@ func (p *AuthProvider) Grant(resources ...string) func(http.Handler) http.Handle
 				return
 			}
 
-			ac := p.ExchangeTokens(r.Context(), authInfo.Token, resources...)
+			ac := p.exchange(r.Context(), authInfo.Issuer, authInfo.Token, resources...)
 			ctx := context.WithValue(r.Context(), accessContextKey, ac)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
-// ExchangeTokens performs token exchange directly and returns an AccessContext.
+// ExchangeTokens performs token exchange for a single-zone provider and returns an
+// AccessContext. For a multi-zone provider use ExchangeTokensForZone, or Grant (which
+// routes by the verified token's issuer).
 func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, resources ...string) *AccessContext {
+	return p.exchange(ctx, "", subjectToken, resources...)
+}
+
+// ExchangeTokensForZone performs token exchange against the given zone (issuer URL),
+// selecting that zone's credential. It fails closed if the zone is not configured.
+func (p *AuthProvider) ExchangeTokensForZone(ctx context.Context, issuer, subjectToken string, resources ...string) *AccessContext {
+	return p.exchange(ctx, issuer, subjectToken, resources...)
+}
+
+func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken string, resources ...string) *AccessContext {
 	ac := NewAccessContext()
 
-	client, err := p.getOrCreateClient()
+	zone, err := p.resolveZone(issuer)
 	if err != nil {
 		ac.SetError(ErrorDetail{
-			Message:  "Failed to initialize OAuth client. Server configuration issue.",
+			Message:  "Could not resolve the request's zone.",
 			RawError: err.Error(),
 		})
 		return ac
 	}
 
+	client := p.clientForZone(zone)
 	tokens := make(map[string]*oauth.TokenResponse)
 
 	// Resolve the token endpoint for credential assertion audience.
@@ -313,24 +344,45 @@ func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, 
 	return ac
 }
 
-func (p *AuthProvider) getOrCreateClient() (*oauth.TokenExchangeClient, error) {
-	p.clientOnce.Do(func() {
-		var clientOpts []oauth.TokenExchangeClientOption
+// resolveZone picks the zone issuer URL for an exchange. A single-zone provider always
+// uses its configured zone (the issuer is ignored). A multi-zone provider requires the
+// issuer to be one of its configured zones and fails closed otherwise.
+func (p *AuthProvider) resolveZone(issuer string) (string, error) {
+	if !p.multiZone {
+		return p.defaultZone, nil
+	}
+	if issuer == "" {
+		return "", fmt.Errorf("multi-zone provider could not resolve a zone: the token has no issuer")
+	}
+	if !p.zones[issuer] {
+		return "", fmt.Errorf("multi-zone provider has no credential configured for zone %q", issuer)
+	}
+	return issuer, nil
+}
 
-		if p.httpClient != nil {
-			clientOpts = append(clientOpts, oauth.WithTokenExchangeHTTPClient(p.httpClient))
+// clientForZone returns the token-exchange client for a zone, creating it on first use
+// with that zone's issuer and credential. Clients are cached per zone.
+func (p *AuthProvider) clientForZone(zone string) *oauth.TokenExchangeClient {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if c, ok := p.clients[zone]; ok {
+		return c
+	}
+
+	var clientOpts []oauth.TokenExchangeClientOption
+	if p.httpClient != nil {
+		clientOpts = append(clientOpts, oauth.WithTokenExchangeHTTPClient(p.httpClient))
+	}
+	if p.credential != nil {
+		if auth := p.credential.Auth(zone); auth != nil {
+			clientOpts = append(clientOpts, oauth.WithClientCredentials(auth.ClientID, auth.ClientSecret))
 		}
+	}
 
-		if p.credential != nil {
-			if auth := p.credential.Auth(); auth != nil {
-				clientOpts = append(clientOpts, oauth.WithClientCredentials(auth.ClientID, auth.ClientSecret))
-			}
-		}
-
-		p.client = oauth.NewTokenExchangeClient(p.zoneURL, clientOpts...)
-	})
-
-	return p.client, p.clientErr
+	c := oauth.NewTokenExchangeClient(zone, clientOpts...)
+	p.clients[zone] = c
+	return c
 }
 
 func buildZoneURL(zoneID, baseURL string) string {

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -294,6 +294,13 @@ func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken string
 	}
 
 	client := p.clientForZone(zone)
+	if client == nil {
+		ac.SetError(ErrorDetail{
+			Message:  "Could not resolve the request's zone.",
+			RawError: fmt.Sprintf("no token-exchange client for zone %q", zone),
+		})
+		return ac
+	}
 	tokens := make(map[string]*oauth.TokenResponse)
 
 	// Resolve the token endpoint for credential assertion audience.
@@ -366,18 +373,23 @@ func (p *AuthProvider) resolveZone(issuer string) (string, error) {
 	return issuer, nil
 }
 
-// clientForZone returns the token-exchange client for a zone, creating it on first use
-// with that zone's issuer and credential. Clients are cached per zone.
+// clientForZone returns the token-exchange client for a configured zone, creating it on
+// first use with the zone's issuer and credential and caching it. It returns nil when the
+// zone is not configured: a client is only minted for a zone the map already holds, so an
+// unknown zone never gets one. Callers resolve the zone with resolveZone first.
 func (p *AuthProvider) clientForZone(zone string) *oauth.TokenExchangeClient {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// A zone is registered with a nil client until its first use, so a present-but-nil
-	// entry means "configured, not yet created" and must fall through to creation.
-	if c, ok := p.clients[zone]; ok && c != nil {
+	c, ok := p.clients[zone]
+	if !ok {
+		return nil
+	}
+	if c != nil {
 		return c
 	}
 
+	// Configured but not yet created: build the client on first use and cache it.
 	var clientOpts []oauth.TokenExchangeClientOption
 	if p.httpClient != nil {
 		clientOpts = append(clientOpts, oauth.WithTokenExchangeHTTPClient(p.httpClient))
@@ -388,7 +400,7 @@ func (p *AuthProvider) clientForZone(zone string) *oauth.TokenExchangeClient {
 		}
 	}
 
-	c := oauth.NewTokenExchangeClient(zone, clientOpts...)
+	c = oauth.NewTokenExchangeClient(zone, clientOpts...)
 	p.clients[zone] = c
 	return c
 }

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -192,13 +192,14 @@ func WithProviderHTTPClient(c *http.Client) AuthProviderOption {
 // routes each exchange to the zone that minted the request's token.
 type AuthProvider struct {
 	multiZone   bool
-	defaultZone string          // single-zone issuer URL ("" when multi-zone)
-	zones       map[string]bool // configured zone issuer URLs
+	defaultZone string // single-zone issuer URL ("" when multi-zone)
 	credential  ApplicationCredential
 	httpClient  *http.Client
 
-	mu      sync.Mutex
-	clients map[string]*oauth.TokenExchangeClient // per-zone, lazily created
+	mu sync.Mutex
+	// clients is keyed by zone issuer URL. A key's presence marks a configured zone;
+	// the value is that zone's token-exchange client, created lazily (nil until first use).
+	clients map[string]*oauth.TokenExchangeClient
 }
 
 // NewAuthProvider creates a new AuthProvider with the given options. With a multi-zone
@@ -216,15 +217,15 @@ func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 	p := &AuthProvider{
 		credential: cfg.applicationCredential,
 		httpClient: cfg.httpClient,
-		zones:      make(map[string]bool),
 		clients:    make(map[string]*oauth.TokenExchangeClient),
 	}
 
-	// A multi-zone credential is self-describing: it carries the zone set.
+	// A multi-zone credential is self-describing: it carries the zone set. Register each
+	// zone with a nil client; the client is created on first use in clientForZone.
 	if mz, ok := cfg.applicationCredential.(MultiZoneCredential); ok && len(mz.Zones()) > 0 {
 		p.multiZone = true
 		for _, zone := range mz.Zones() {
-			p.zones[zone] = true
+			p.clients[zone] = nil
 		}
 		return p, nil
 	}
@@ -239,7 +240,7 @@ func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 		}
 	}
 	p.defaultZone = zoneURL
-	p.zones[zoneURL] = true
+	p.clients[zoneURL] = nil
 	return p, nil
 }
 
@@ -354,7 +355,12 @@ func (p *AuthProvider) resolveZone(issuer string) (string, error) {
 	if issuer == "" {
 		return "", fmt.Errorf("multi-zone provider could not resolve a zone: the token has no issuer")
 	}
-	if !p.zones[issuer] {
+	// clients is guarded by mu (clientForZone mutates it), so take the lock for the
+	// membership check even though we only read it here.
+	p.mu.Lock()
+	_, configured := p.clients[issuer]
+	p.mu.Unlock()
+	if !configured {
 		return "", fmt.Errorf("multi-zone provider has no credential configured for zone %q", issuer)
 	}
 	return issuer, nil
@@ -366,7 +372,9 @@ func (p *AuthProvider) clientForZone(zone string) *oauth.TokenExchangeClient {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if c, ok := p.clients[zone]; ok {
+	// A zone is registered with a nil client until its first use, so a present-but-nil
+	// entry means "configured, not yet created" and must fall through to creation.
+	if c, ok := p.clients[zone]; ok && c != nil {
 		return c
 	}
 

--- a/mcp/provider_test.go
+++ b/mcp/provider_test.go
@@ -121,7 +121,7 @@ type capturingCredential struct {
 	capturedOpts *PrepareOptions
 }
 
-func (c *capturingCredential) Auth() *ClientAuth {
+func (c *capturingCredential) Auth(_ string) *ClientAuth {
 	return &ClientAuth{ClientID: "test-client", ClientSecret: "test-secret"}
 }
 
@@ -191,8 +191,8 @@ func TestNewAuthProvider_BuildsZoneURLFromID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if provider.zoneURL != "https://my-zone.keycard.cloud" {
-		t.Errorf("zoneURL: got %q", provider.zoneURL)
+	if provider.defaultZone != "https://my-zone.keycard.cloud" {
+		t.Errorf("defaultZone: got %q", provider.defaultZone)
 	}
 }
 

--- a/mcp/verifier.go
+++ b/mcp/verifier.go
@@ -13,6 +13,9 @@ type AuthInfo struct {
 	Scopes    []string
 	Resource  string
 	ExpiresAt int64
+	// Issuer is the verified token's iss claim. It identifies the zone that minted
+	// the token and is used to route the outbound exchange in a multi-zone provider.
+	Issuer string
 }
 
 // TokenVerifier verifies access tokens and returns auth information.
@@ -47,6 +50,14 @@ func NewZoneTokenVerifier(zoneURL string, opts ...oauth.JWTVerifierOption) (*JWT
 	return NewJWTOAuthTokenVerifier(oauth.NewJWKSOAuthKeyring(), []string{zoneURL}, opts...)
 }
 
+// NewMultiZoneTokenVerifier builds a verifier that trusts tokens from any of zoneURLs,
+// resolving each token's verification key from its own zone's JWKS. The token's iss
+// claim selects the zone; a token whose iss is not one of zoneURLs is rejected. This is
+// the inbound half of multi-zone support.
+func NewMultiZoneTokenVerifier(zoneURLs []string, opts ...oauth.JWTVerifierOption) (*JWTOAuthTokenVerifier, error) {
+	return NewJWTOAuthTokenVerifier(oauth.NewJWKSOAuthKeyring(), zoneURLs, opts...)
+}
+
 // VerifyAccessToken verifies a JWT access token and returns auth information.
 func (v *JWTOAuthTokenVerifier) VerifyAccessToken(ctx context.Context, token string) (*AuthInfo, error) {
 	claims, err := v.verifier.Verify(ctx, token)
@@ -58,6 +69,7 @@ func (v *JWTOAuthTokenVerifier) VerifyAccessToken(ctx context.Context, token str
 		Token:    token,
 		ClientID: claims.ClientID,
 		Scopes:   parseScopes(claims.Scope),
+		Issuer:   claims.Issuer,
 	}
 
 	if claims.Expiry != 0 {


### PR DESCRIPTION
## What

Implements the [multi-zone-support](https://github.com/keycardai/keycard-sdk-spec/blob/main/specs/multi-zone-and-ops/multi-zone-support.md) spec — one `AuthProvider` instance serving many Keycard zones, routing each request by the token's issuer. Go was the only SDK without multi-zone. Closes ECO-93.

> **Stacked on #13.** Multi-zone builds on the Phase 1 multi-issuer verifier (`NewJWTOAuthTokenVerifier(keyring, issuers…)`, per-issuer JWKS isolation), so the base is `jwt-signing-and-verification`. Merge #13 first (GitHub will retarget this to `main`).

## Changes

- **`NewMultiZoneClientSecret(map[issuer]ClientAuth)`** — a self-describing, zone-keyed credential. `ApplicationCredential.Auth()` becomes **`Auth(issuer string)`**, resolving per-zone credentials; assertion-based credentials ignore the issuer, and an unknown zone returns `nil` (fail-closed). New optional `MultiZoneCredential` interface (`Zones()`).
- **`AuthProvider`** detects multi-zone from the credential and keeps a per-zone `TokenExchangeClient`, so discovery/client caches are zone-scoped. `Grant` routes the exchange to `AuthInfo.Issuer`; new `ExchangeTokensForZone` selects a zone explicitly; an unresolved or unconfigured zone fails closed with a global `AccessContext` error.
- **Inbound:** `AuthInfo.Issuer` (the verified `iss`) + `NewMultiZoneTokenVerifier([]zones)`. The token's `iss` selects the zone and its JWKS — a zone-A token can only verify with zone-A's key.

Zone resolution is the verified token's `iss`; the spec calls the resolution layer an intended per-framework idiom, so a pluggable request-based resolver can be added later if a customer needs one.

## Tests

The spec's six unit cases: per-zone credential resolution, issuer-routed exchange, no cross-zone leakage (interleaved zones), fail-closed on unresolved and unknown zones, and an end-to-end `Grant` routed by the token issuer. Plus a runnable `examples/multi-zone`. `go vet`, `go test -race`, `go build ./examples/...`, gofmt all clean.

## Breaking change

`ApplicationCredential.Auth()` → `Auth(issuer string)`. Custom credential implementations update the signature. Acceptable under v0.x preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
