### PR TITLE
ci: push version bumps with the GH_REPO_ACCESS app token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,20 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Push the bump commit with the GH_REPO_ACCESS app token (matching python-sdk
+      # and typescript-sdk). The default GITHUB_TOKEN cannot push to main, which
+      # requires changes via PR under the org ruleset; the app is on the bypass list.
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.GH_REPO_ACCESS_PRIVATE_KEY }}
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Python


### PR DESCRIPTION
## Problem

The **CI** check passes on every PR, but the post-merge **"Merge to Main"** bump job has failed on the last two merges ([#13](https://github.com/keycardai/credentials-go/pull/13), [#14](https://github.com/keycardai/credentials-go/pull/14)):

```
bump: credentials-go 0.3.0 → 0.4.0
Push failed: remote: error: GH013: Repository rule violations found for refs/heads/main.
 - Changes must be made through a pull request.
```

The job computes the version bump and pushes it **directly to `main`** using the default `GITHUB_TOKEN`. `main` is governed by an org-level ruleset that requires changes via PR, and the `GITHUB_TOKEN` is not on its bypass list — so the push is rejected and the job fails on every releasable merge. Result: merged code is unreleased (manifest still `0.3.0`, no `0.4.0` tag).

## Fix

Push with the **`GH_REPO_ACCESS` GitHub App token** instead — the same identity `python-sdk` and `typescript-sdk` use to push releases (`actions/create-github-app-token@v2` → `checkout(token)`). `scripts/bump.py` already sets its own git identity, so only the token wiring changes.

## Effect

Once merged, the bump job runs with the app token. It will also pick up the **pending `0.3.0 → 0.4.0`** bump from #13's `feat!` (cz looks at all unreleased commits since the last tag), completing the release that didn't land.

## If it still fails (admin follow-up)

This assumes the `GH_REPO_ACCESS` app is installed on this repo, its `GH_REPO_ACCESS_APP_ID` / `GH_REPO_ACCESS_PRIVATE_KEY` secrets are available here, and the app is on the org ruleset's bypass list — all true for python-sdk/typescript-sdk, so most likely already in place org-wide. If the post-merge run still hits `GH013`, the remaining step is purely admin: share those secrets to this repo / add the app to the ruleset bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
