### PR TITLE
docs: add authorization-server discovery example

### DIFF
--- a/examples/discovery/main.go
+++ b/examples/discovery/main.go
@@ -1,0 +1,45 @@
+// Package main demonstrates authorization-server discovery (RFC 8414): it fetches a
+// Keycard zone's OAuth metadata and prints the advertised endpoints. This is the first
+// call every other operation makes against a zone.
+//
+// Configure before running:
+//   - KEYCARD_ZONE_URL, e.g. https://your-zone.keycard.cloud
+//
+// Run:
+//
+//	KEYCARD_ZONE_URL=... go run ./examples/discovery
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+func main() {
+	zoneURL := os.Getenv("KEYCARD_ZONE_URL")
+	if zoneURL == "" {
+		log.Fatal("KEYCARD_ZONE_URL environment variable is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	metadata, err := oauth.FetchAuthorizationServerMetadata(ctx, zoneURL)
+	if err != nil {
+		log.Fatalf("discovery failed: %v", err)
+	}
+
+	fmt.Printf("issuer:                 %s\n", metadata.Issuer)
+	fmt.Printf("authorization_endpoint: %s\n", metadata.AuthorizationEndpoint)
+	fmt.Printf("token_endpoint:         %s\n", metadata.TokenEndpoint)
+	fmt.Printf("jwks_uri:               %s\n", metadata.JWKSURI)
+	fmt.Printf("registration_endpoint:  %s\n", metadata.RegistrationEndpoint)
+	if len(metadata.ScopesSupported) > 0 {
+		fmt.Printf("scopes_supported:       %v\n", metadata.ScopesSupported)
+	}
+}


### PR DESCRIPTION
## What

Adds `examples/discovery`, mirroring python-sdk's `discover_server_metadata` example. It fetches a zone's RFC 8414 metadata via `oauth.FetchAuthorizationServerMetadata` and prints the advertised endpoints.

## Why

Rounds out the Go example surface to match the other SDKs. Discovery is the first call every other operation makes against a zone, but it was only exercised implicitly (inside the other examples) and had no standalone demo. python-sdk ships `discover_server_metadata`; this is the Go equivalent.

Runs against local source (root module, no separate `go.mod`); `go build ./examples/...` covers it in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
