### PR TITLE
ci: match scoped commits in the cz changelog pattern

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -7,4 +7,7 @@ bump_message = "bump: credentials-go $current_version → $new_version"
 major_version_zero = true
 
 [tool.commitizen.customize]
-changelog_pattern = "^(feat|fix|refactor|perf|test|build|ci|revert)(!)?:"
+# The optional (\(.+\))? scope group is required: without it a scoped subject like
+# "feat(oauth): ..." does not match, so cz reports no unreleased changes and the release
+# is silently skipped. Literal string so the regex backslashes are not TOML-escaped.
+changelog_pattern = '^(feat|fix|refactor|perf|test|build|ci|revert)(\(.+\))?(!)?:'


### PR DESCRIPTION
## Problem

`.cz.toml`'s `changelog_pattern` had no scope group:

```
^(feat|fix|refactor|perf|test|build|ci|revert)(!)?:
```

So a **scoped** subject like `feat(oauth): ...` does not match. `scripts/bump.py` gates the release on `cz changelog --dry-run` (`has_unreleased_changes`), which then reports nothing and skips the bump. That is why **impersonation (#12) merged but never released** (still v0.6.0): its squash subject was `feat(oauth): … (#12)`. #15/#16 released only because they were unscoped `feat:`. Every future scoped commit would silently skip release the same way.

## Fix

Add the optional `(\(.+\))?` scope group (cz-conventional style):

```
^(feat|fix|refactor|perf|test|build|ci|revert)(\(.+\))?(!)?:
```

(Literal TOML string so the regex backslashes are not TOML-escaped.)

## Verified with `cz` against current `main`

- `cz changelog --dry-run` now lists the unreleased `feat(oauth): … (#12)` commit (it was empty before).
- `cz bump --dry-run --yes` → `bump: credentials-go 0.6.0 → 0.7.0`, `increment detected: MINOR`.
- Regex check: scoped (`feat(oauth):`, `fix(eval)!:`) now match; unscoped (`feat:`, `ci:`) still match; `chore:` still does not.

Merging this cuts **v0.7.0**, which includes the already-merged impersonation feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
