### PR TITLE
fix: advertise path-inserted protected-resource metadata and default authorization_servers (ACC-591)

### DIFF
--- a/mcp/metadata.go
+++ b/mcp/metadata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // ProtectedResourceMetadata represents OAuth Protected Resource Metadata.
@@ -65,17 +66,19 @@ func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+	// protectedResource serves the Protected Resource Metadata (RFC 9728). It is registered
+	// for both the bare well-known path (origin resource) and the path-inserted form
+	// (e.g. /.well-known/oauth-protected-resource/mcp), so a resource mounted at a sub-path
+	// advertises and resolves to its full URL rather than the bare origin.
+	protectedResource := func(w http.ResponseWriter, r *http.Request) {
 		setCORSHeaders(w)
 
 		scheme := requestScheme(r)
 		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
-		path := r.URL.Path
-		if path == "/.well-known/oauth-protected-resource" {
-			path = ""
-		}
-		resource := baseURL + path
+		// The resource is the origin plus the path that follows the well-known prefix:
+		// "" for the origin resource, "/mcp" for the path-inserted form.
+		resource := baseURL + strings.TrimPrefix(r.URL.Path, "/.well-known/oauth-protected-resource")
 
 		metadata := ProtectedResourceMetadata{
 			Resource:              resource,
@@ -83,16 +86,15 @@ func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 			ResourceName:          cfg.resourceName,
 			ResourceDocumentation: cfg.resourceDocumentation,
 		}
-
-		// Handle MCP protocol version for backward compatibility
-		mcpVersion := r.Header.Get("MCP-Protocol-Version")
-		if mcpVersion == "2025-03-26" {
-			metadata.AuthorizationServers = []string{baseURL}
+		if cfg.issuer != "" {
+			metadata.AuthorizationServers = []string{cfg.issuer}
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metadata)
-	})
+	}
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", protectedResource)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/{resourcePath...}", protectedResource)
 
 	if cfg.issuer != "" {
 		mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {

--- a/mcp/metadata.go
+++ b/mcp/metadata.go
@@ -55,6 +55,11 @@ func WithMetadataHTTPClient(c *http.Client) MetadataOption {
 
 // AuthMetadataHandler returns an http.Handler that serves both
 // /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server endpoints.
+//
+// An issuer (WithIssuer) is effectively required for a usable deployment: without it the
+// protected-resource metadata advertises no authorization_servers and the
+// authorization-server proxy route is not registered, leaving clients no way to discover
+// the authorization server.
 func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 	cfg := metadataConfig{}
 	for _, opt := range opts {

--- a/mcp/metadata.go
+++ b/mcp/metadata.go
@@ -77,8 +77,10 @@ func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
 		// The resource is the origin plus the path that follows the well-known prefix:
-		// "" for the origin resource, "/mcp" for the path-inserted form.
-		resource := baseURL + strings.TrimPrefix(r.URL.Path, "/.well-known/oauth-protected-resource")
+		// "" for the origin resource, "/mcp" for the path-inserted form. A trailing slash
+		// (e.g. the bare path-inserted form ".../oauth-protected-resource/") normalizes to
+		// the origin so the advertised resource matches an origin-bound audience exactly.
+		resource := baseURL + strings.TrimRight(strings.TrimPrefix(r.URL.Path, "/.well-known/oauth-protected-resource"), "/")
 
 		metadata := ProtectedResourceMetadata{
 			Resource:              resource,
@@ -93,8 +95,11 @@ func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(metadata)
 	}
+	// Two routes: the exact bare path (origin resource) and the subtree for the
+	// path-inserted form (.../oauth-protected-resource/mcp). The handler derives the
+	// resource from r.URL.Path, so no path wildcard binding is needed.
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource", protectedResource)
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource/{resourcePath...}", protectedResource)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/", protectedResource)
 
 	if cfg.issuer != "" {
 		mux.HandleFunc("GET /.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {

--- a/mcp/metadata_test.go
+++ b/mcp/metadata_test.go
@@ -35,24 +35,49 @@ func TestAuthMetadataHandler_ProtectedResource(t *testing.T) {
 	if len(metadata.ScopesSupported) != 2 {
 		t.Errorf("scopes: got %v", metadata.ScopesSupported)
 	}
+	if metadata.Resource != "http://example.com" {
+		t.Errorf("resource: got %q, want http://example.com (origin)", metadata.Resource)
+	}
 }
 
-func TestAuthMetadataHandler_MCPProtocolVersion(t *testing.T) {
+func TestAuthMetadataHandler_AuthorizationServersDefault(t *testing.T) {
 	handler := AuthMetadataHandler(
+		WithIssuer("https://zone.example.com"),
 		WithScopesSupported([]string{"mcp:tools"}),
 	)
 
 	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
-	req.Header.Set("MCP-Protocol-Version", "2025-03-26")
 	rec := httptest.NewRecorder()
-
 	handler.ServeHTTP(rec, req)
 
 	var metadata ProtectedResourceMetadata
 	json.NewDecoder(rec.Body).Decode(&metadata)
 
-	if len(metadata.AuthorizationServers) != 1 {
-		t.Errorf("expected 1 authorization server for 2025-03-26, got %d", len(metadata.AuthorizationServers))
+	if len(metadata.AuthorizationServers) != 1 || metadata.AuthorizationServers[0] != "https://zone.example.com" {
+		t.Errorf("authorization_servers: got %v, want [https://zone.example.com]", metadata.AuthorizationServers)
+	}
+}
+
+func TestAuthMetadataHandler_PathInsertedResource(t *testing.T) {
+	handler := AuthMetadataHandler(WithIssuer("https://zone.example.com"))
+
+	// RFC 9728 path insertion: a resource mounted at /mcp is advertised under
+	// .well-known/oauth-protected-resource/mcp and must resolve to host + /mcp,
+	// not the bare origin (the bug in ACC-591).
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource/mcp", nil)
+	req.Host = "mcp.example.com"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var metadata ProtectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&metadata); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if metadata.Resource != "http://mcp.example.com/mcp" {
+		t.Errorf("resource: got %q, want http://mcp.example.com/mcp", metadata.Resource)
 	}
 }
 

--- a/mcp/metadata_test.go
+++ b/mcp/metadata_test.go
@@ -81,6 +81,40 @@ func TestAuthMetadataHandler_PathInsertedResource(t *testing.T) {
 	}
 }
 
+func TestAuthMetadataHandler_AuthorizationServersOmittedWithoutIssuer(t *testing.T) {
+	// With no issuer configured, authorization_servers is omitted entirely (omitempty).
+	// This is the contract change from dropping the MCP-Protocol-Version origin-as-AS
+	// branch; a correct Keycard deployment always sets WithIssuer (the zone).
+	handler := AuthMetadataHandler(WithScopesSupported([]string{"mcp:tools"}))
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var metadata ProtectedResourceMetadata
+	json.NewDecoder(rec.Body).Decode(&metadata)
+	if len(metadata.AuthorizationServers) != 0 {
+		t.Errorf("authorization_servers: got %v, want empty when no issuer is configured", metadata.AuthorizationServers)
+	}
+}
+
+func TestAuthMetadataHandler_PathInsertedTrailingSlash(t *testing.T) {
+	handler := AuthMetadataHandler(WithIssuer("https://zone.example.com"))
+
+	// A path-inserted form with a trailing slash normalizes to the origin, so the
+	// advertised resource still matches an origin-bound audience exactly.
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource/", nil)
+	req.Host = "mcp.example.com"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var metadata ProtectedResourceMetadata
+	json.NewDecoder(rec.Body).Decode(&metadata)
+	if metadata.Resource != "http://mcp.example.com" {
+		t.Errorf("resource: got %q, want http://mcp.example.com (trailing slash normalized)", metadata.Resource)
+	}
+}
+
 func TestAuthMetadataHandler_AuthorizationServer(t *testing.T) {
 	// Mock upstream authorization server
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/mcp/middleware.go
+++ b/mcp/middleware.go
@@ -143,7 +143,11 @@ func RequireBearerAuth(verifier TokenVerifier, opts ...BearerAuthOption) func(ht
 	}
 }
 
-// protectedResourceMetadataURL constructs the well-known URL for the protected resource metadata.
+// protectedResourceMetadataURL constructs the well-known URL for the protected resource
+// metadata. Following RFC 9728 path insertion, the protected resource's path is appended
+// after the well-known segment (e.g. a resource at /mcp advertises
+// .../.well-known/oauth-protected-resource/mcp), so the metadata, and the resource audience
+// it carries, match the full endpoint URL rather than the bare origin.
 func protectedResourceMetadataURL(r *http.Request) string {
 	scheme := "https"
 	if r.TLS == nil {
@@ -153,5 +157,9 @@ func protectedResourceMetadataURL(r *http.Request) string {
 			scheme = "http"
 		}
 	}
-	return fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", scheme, r.Host)
+	resourcePath := r.URL.Path
+	if resourcePath == "/" {
+		resourcePath = ""
+	}
+	return fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource%s", scheme, r.Host, resourcePath)
 }

--- a/mcp/middleware_test.go
+++ b/mcp/middleware_test.go
@@ -71,6 +71,26 @@ func TestRequireBearerAuth_MissingHeader(t *testing.T) {
 	}
 }
 
+func TestRequireBearerAuth_ChallengeIncludesResourcePath(t *testing.T) {
+	verifier := &mockTokenVerifier{}
+
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	}))
+
+	// RFC 9728 path insertion: the challenge for a resource at /mcp must advertise
+	// .well-known/oauth-protected-resource/mcp, not the bare origin (ACC-591).
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	challenge := rec.Header().Get("WWW-Authenticate")
+	if !strings.Contains(challenge, "/.well-known/oauth-protected-resource/mcp") {
+		t.Errorf("expected path-inserted resource_metadata in challenge, got %q", challenge)
+	}
+}
+
 func TestRequireBearerAuth_MalformedHeader(t *testing.T) {
 	verifier := &mockTokenVerifier{}
 

--- a/mcp/middleware_test.go
+++ b/mcp/middleware_test.go
@@ -91,6 +91,25 @@ func TestRequireBearerAuth_ChallengeIncludesResourcePath(t *testing.T) {
 	}
 }
 
+func TestRequireBearerAuth_ChallengeRootPath(t *testing.T) {
+	verifier := &mockTokenVerifier{}
+
+	handler := RequireBearerAuth(verifier)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	}))
+
+	// A resource at the root advertises the bare well-known path, with no trailing slash.
+	req := httptest.NewRequest("POST", "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	challenge := rec.Header().Get("WWW-Authenticate")
+	if !strings.Contains(challenge, `/.well-known/oauth-protected-resource"`) {
+		t.Errorf("expected bare resource_metadata (no trailing path) for root resource, got %q", challenge)
+	}
+}
+
 func TestRequireBearerAuth_MalformedHeader(t *testing.T) {
 	verifier := &mockTokenVerifier{}
 


### PR DESCRIPTION
## What

Fixes [ACC-591](https://linear.app/keycardlabs/issue/ACC-591) and the `oauth-metadata-endpoints` item of ECO-94. Two related corrections to the `mcp` package's metadata + bearer challenge:

### 1. RFC 9728 path insertion (ACC-591)

The advertising side never applied path insertion: the `WWW-Authenticate` challenge and the Protected Resource Metadata both resolved `resource` to the bare **origin** (`http://host`), dropping the request path. A server that binds its token audience to the full endpoint URL (`http://host/mcp`, the registered zone resource) rejected every token, because discovery told the client to request `resource=origin`, whose `aud` never matched. TS already does path insertion, so this was a Go↔TS parity gap.

- `mcp/middleware.go` `protectedResourceMetadataURL` now appends the request path: a resource at `/mcp` advertises `.../.well-known/oauth-protected-resource/mcp`.
- `mcp/metadata.go` `AuthMetadataHandler` now also serves the path-inserted route and resolves `resource` to origin + the path after the well-known prefix. The bare origin route is unchanged.

### 2. `authorization_servers` default (ECO-94)

`authorization_servers` was omitted unless the request carried `MCP-Protocol-Version: 2025-03-26`, and then it was set to the resource origin rather than the issuer. It now defaults to `[issuer]` whenever an issuer is configured, and the legacy `2025-03-26` special case is removed.

This matches **Python**, which has no protocol-version branch and always emits the configured issuer. **TypeScript still carries the `2025-03-26` → `[origin]` shim**, so a legacy `2025-03-26` client gets `[issuer]` from Go and `[origin]` from TS until TS converges (tracked separately). Functional risk is low: Go still serves the proxied `/.well-known/oauth-authorization-server` route, and Python already ships this behavior. (Corrected from an earlier "Python/TS parity" claim.)

## Tests

Path-inserted resource resolution, trailing-slash handling, root/origin route, `authorization_servers` default and omitted-without-issuer, and the path-inserted 401 challenge. `go build` / `go vet` / `go test -race` clean.

## Review follow-ups

- Rebased onto current `main` (post multi-zone) and re-verified build / vet / `go test -race`.
- Documented on `AuthMetadataHandler` that an issuer is effectively required for a usable PRM.
- The dropped `2025-03-26` shim and the trailing-slash trim on sub-paths are intentional Python-aligned choices where TS differs on the margin.
- Latent, pre-existing, shared with TS, out of scope: the challenge and metadata derive the host from `r.Host`, honoring `X-Forwarded-Proto` but not `X-Forwarded-Host`; behind a host-rewriting proxy the advertised resource would carry the internal host. Tracked as a follow-up.

## Note

`WithPublicJWKS` (serving `/.well-known/jwks.json`) is the remaining `oauth-metadata-endpoints` checklist item and will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)