### PR TITLE
feat: oauth conformance polish - discovery/token-exchange/jwks/error-model (ECO-94)

### DIFF
--- a/oauth/authorization_code.go
+++ b/oauth/authorization_code.go
@@ -155,18 +155,8 @@ func exchangeCodeAtEndpoint(ctx context.Context, tokenEndpoint string, req Autho
 // oauthErrorFromResponse converts a non-2xx token-endpoint response into an *OAuthError
 // when the body carries an RFC 6749 §5.2 error, or a generic error otherwise.
 func oauthErrorFromResponse(resp *http.Response) error {
-	var errBody map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
-		if errCode, ok := errBody["error"].(string); ok {
-			oauthErr := &OAuthError{ErrorCode: errCode, Message: errCode}
-			if desc, ok := errBody["error_description"].(string); ok {
-				oauthErr.Message = desc
-			}
-			if uri, ok := errBody["error_uri"].(string); ok {
-				oauthErr.ErrorURI = uri
-			}
-			return oauthErr
-		}
+	if oauthErr := parseOAuthErrorResponse(resp); oauthErr != nil {
+		return oauthErr
 	}
 	return fmt.Errorf("token endpoint returned HTTP %d", resp.StatusCode)
 }

--- a/oauth/client_credentials.go
+++ b/oauth/client_credentials.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -101,22 +100,8 @@ func (c *ClientCredentialsClient) RequestToken(ctx context.Context, req ClientCr
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		var errBody map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
-			if errCode, ok := errBody["error"].(string); ok {
-				oauthErr := &OAuthError{
-					ErrorCode: errCode,
-				}
-				if desc, ok := errBody["error_description"].(string); ok {
-					oauthErr.Message = desc
-				} else {
-					oauthErr.Message = errCode
-				}
-				if uri, ok := errBody["error_uri"].(string); ok {
-					oauthErr.ErrorURI = uri
-				}
-				return nil, oauthErr
-			}
+		if oauthErr := parseOAuthErrorResponse(resp); oauthErr != nil {
+			return nil, oauthErr
 		}
 		return nil, fmt.Errorf("client credentials request failed (HTTP %d)", resp.StatusCode)
 	}

--- a/oauth/conformance_test.go
+++ b/oauth/conformance_test.go
@@ -1,0 +1,200 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- authorization-server discovery validation ---
+
+func TestFetchAuthorizationServerMetadata_IssuerMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"issuer": "https://attacker.example.com"})
+	}))
+	defer server.Close()
+
+	_, err := FetchAuthorizationServerMetadata(context.Background(), server.URL)
+	var mismatch *IssuerMismatchError
+	if err == nil || !errors.As(err, &mismatch) {
+		t.Fatalf("expected *IssuerMismatchError, got %v", err)
+	}
+}
+
+func TestFetchAuthorizationServerMetadata_TrailingSlash(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Report the issuer with a trailing slash; it must still match a request without one.
+		json.NewEncoder(w).Encode(map[string]string{"issuer": serverURL + "/"})
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	if _, err := FetchAuthorizationServerMetadata(context.Background(), server.URL); err != nil {
+		t.Fatalf("trailing slash should be tolerated, got %v", err)
+	}
+}
+
+func TestFetchAuthorizationServerMetadata_UnknownFieldsPreserved(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 serverURL,
+			"token_endpoint":         serverURL + "/token",
+			"code_challenge_methods": []string{"S256"},
+			"some_vendor_extension":  "keep-me",
+		})
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	md, err := FetchAuthorizationServerMetadata(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if md.Extra["some_vendor_extension"] != "keep-me" {
+		t.Errorf("unknown field not preserved: Extra=%v", md.Extra)
+	}
+	if _, ok := md.Extra["issuer"]; ok {
+		t.Error("known field 'issuer' should not appear in Extra")
+	}
+}
+
+// --- token-exchange response defaults ---
+
+func TestDeserializeTokenResponse_BearerDefaultAndIDToken(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(
+		`{"access_token":"at","id_token":"the-id-token"}`))}
+	tr, err := deserializeTokenResponse(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.TokenType != "Bearer" {
+		t.Errorf("token_type default: got %q, want Bearer", tr.TokenType)
+	}
+	if tr.IDToken != "the-id-token" {
+		t.Errorf("id_token: got %q, want the-id-token", tr.IDToken)
+	}
+}
+
+func TestDeserializeTokenResponse_ExplicitTokenTypePreserved(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(
+		`{"access_token":"at","token_type":"DPoP"}`))}
+	tr, err := deserializeTokenResponse(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.TokenType != "DPoP" {
+		t.Errorf("explicit token_type should be preserved: got %q", tr.TokenType)
+	}
+}
+
+// --- JWKS keyring: bounded cache + typed errors ---
+
+// b1RSAJWKS returns an httptest server that serves discovery metadata plus a JWKS
+// document containing one RSA key per kid in kids.
+func b1RSAJWKS(t *testing.T, kids ...string) *httptest.Server {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	n := Base64URLEncode(priv.N.Bytes())
+	e := Base64URLEncode(big.NewInt(int64(priv.E)).Bytes())
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":   srv.URL,
+				"jwks_uri": srv.URL + "/.well-known/jwks.json",
+			})
+		case "/.well-known/jwks.json":
+			keys := make([]map[string]string, 0, len(kids))
+			for _, kid := range kids {
+				keys = append(keys, map[string]string{"kty": "RSA", "kid": kid, "n": n, "e": e})
+			}
+			json.NewEncoder(w).Encode(map[string]any{"keys": keys})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+func TestJWKSOAuthKeyring_BoundedKeyCache(t *testing.T) {
+	srv := b1RSAJWKS(t, "k0", "k1", "k2", "k3", "k4", "k5")
+	defer srv.Close()
+
+	kr := NewJWKSOAuthKeyring(WithMaxKeyCacheSize(3), WithKeyringHTTPClient(srv.Client()))
+	for _, kid := range []string{"k0", "k1", "k2", "k3", "k4", "k5"} {
+		if _, err := kr.Key(context.Background(), srv.URL, kid); err != nil {
+			t.Fatalf("resolving %s: %v", kid, err)
+		}
+	}
+
+	kr.mu.Lock()
+	size := len(kr.keyCache)
+	kr.mu.Unlock()
+	if size > 3 {
+		t.Errorf("key cache not bounded: got %d entries, want <= 3", size)
+	}
+}
+
+func TestJWKSOAuthKeyring_FetchError(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			json.NewEncoder(w).Encode(map[string]string{"issuer": srv.URL, "jwks_uri": srv.URL + "/.well-known/jwks.json"})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	kr := NewJWKSOAuthKeyring(WithKeyringHTTPClient(srv.Client()))
+	_, err := kr.Key(context.Background(), srv.URL, "k0")
+	var fetchErr *JWKSFetchError
+	if err == nil || !errors.As(err, &fetchErr) {
+		t.Fatalf("expected *JWKSFetchError, got %v", err)
+	}
+}
+
+func TestJWKSOAuthKeyring_KeyNotFoundTyped(t *testing.T) {
+	srv := b1RSAJWKS(t, "present-key")
+	defer srv.Close()
+
+	kr := NewJWKSOAuthKeyring(WithKeyringHTTPClient(srv.Client()))
+	_, err := kr.Key(context.Background(), srv.URL, "absent-key")
+	var notFound *JWKSKeyNotFoundError
+	if err == nil || !errors.As(err, &notFound) {
+		t.Fatalf("expected *JWKSKeyNotFoundError, got %v", err)
+	}
+}
+
+func TestJWKSOAuthKeyring_UriValidationError(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			// Cross-origin jwks_uri must be rejected.
+			json.NewEncoder(w).Encode(map[string]string{"issuer": srv.URL, "jwks_uri": "https://evil.example.com/jwks.json"})
+		}
+	}))
+	defer srv.Close()
+
+	kr := NewJWKSOAuthKeyring(WithKeyringHTTPClient(srv.Client()))
+	_, err := kr.Key(context.Background(), srv.URL, "k0")
+	var valErr *JWKSUriValidationError
+	if err == nil || !errors.As(err, &valErr) {
+		t.Fatalf("expected *JWKSUriValidationError, got %v", err)
+	}
+}

--- a/oauth/discovery.go
+++ b/oauth/discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -19,6 +20,16 @@ type AuthorizationServerMetadata struct {
 	ResponseTypesSupported            []string `json:"response_types_supported,omitempty"`
 	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
 	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	// Extra holds any fields beyond the standard set, preserved for forward compatibility.
+	Extra map[string]any `json:"-"`
+}
+
+// knownASMetadataFields are the JSON names mapped to typed fields above; anything else
+// in a discovery response is preserved in AuthorizationServerMetadata.Extra.
+var knownASMetadataFields = []string{
+	"issuer", "authorization_endpoint", "token_endpoint", "jwks_uri",
+	"registration_endpoint", "scopes_supported", "response_types_supported",
+	"grant_types_supported", "token_endpoint_auth_methods_supported",
 }
 
 // DiscoveryOption configures a metadata discovery request.
@@ -67,9 +78,41 @@ func FetchAuthorizationServerMetadata(ctx context.Context, issuer string, opts .
 		}
 	}
 
+	// Read the body once so we can decode the typed fields and also capture any
+	// unknown ones for forward compatibility.
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading authorization server metadata: %w", err)
+	}
+
 	var metadata AuthorizationServerMetadata
-	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+	if err := json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("decoding authorization server metadata: %w", err)
+	}
+
+	// Validate the response issuer matches the requested issuer (RFC 8414 section 3.3),
+	// ignoring a trailing slash.
+	if strings.TrimRight(metadata.Issuer, "/") != issuer {
+		return nil, &IssuerMismatchError{
+			Message: fmt.Sprintf("authorization server issuer %q does not match requested issuer %q", metadata.Issuer, issuer),
+		}
+	}
+
+	// Preserve fields beyond the standard set.
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal(data, &all); err == nil {
+		for _, known := range knownASMetadataFields {
+			delete(all, known)
+		}
+		if len(all) > 0 {
+			metadata.Extra = make(map[string]any, len(all))
+			for k, v := range all {
+				var val any
+				if err := json.Unmarshal(v, &val); err == nil {
+					metadata.Extra[k] = val
+				}
+			}
+		}
 	}
 
 	return &metadata, nil

--- a/oauth/discovery.go
+++ b/oauth/discovery.go
@@ -92,7 +92,7 @@ func FetchAuthorizationServerMetadata(ctx context.Context, issuer string, opts .
 
 	// Validate the response issuer matches the requested issuer (RFC 8414 section 3.3),
 	// ignoring a trailing slash.
-	if strings.TrimRight(metadata.Issuer, "/") != issuer {
+	if strings.TrimRight(metadata.Issuer, "/") != strings.TrimRight(issuer, "/") {
 		return nil, &IssuerMismatchError{
 			Message: fmt.Sprintf("authorization server issuer %q does not match requested issuer %q", metadata.Issuer, issuer),
 		}

--- a/oauth/discovery_test.go
+++ b/oauth/discovery_test.go
@@ -10,9 +10,8 @@ import (
 
 func TestFetchAuthorizationServerMetadata(t *testing.T) {
 	metadata := AuthorizationServerMetadata{
-		Issuer:            "https://auth.example.com",
-		TokenEndpoint:     "https://auth.example.com/token",
-		JWKSURI:           "https://auth.example.com/.well-known/jwks.json",
+		TokenEndpoint:         "https://auth.example.com/token",
+		JWKSURI:               "https://auth.example.com/.well-known/jwks.json",
 		AuthorizationEndpoint: "https://auth.example.com/authorize",
 	}
 
@@ -26,6 +25,8 @@ func TestFetchAuthorizationServerMetadata(t *testing.T) {
 		json.NewEncoder(w).Encode(metadata)
 	}))
 	defer server.Close()
+	// A real authorization server reports its own URL as the issuer.
+	metadata.Issuer = server.URL
 
 	result, err := FetchAuthorizationServerMetadata(context.Background(), server.URL)
 	if err != nil {

--- a/oauth/discovery_test.go
+++ b/oauth/discovery_test.go
@@ -5,8 +5,41 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 )
+
+// knownASMetadataFields must stay in sync with the json-tagged fields of
+// AuthorizationServerMetadata: a typed field missing from the list would be duplicated
+// into Extra, and a stale entry would silently strip a field that no longer exists.
+func TestKnownASMetadataFieldsMatchStruct(t *testing.T) {
+	tagged := map[string]bool{}
+	rt := reflect.TypeOf(AuthorizationServerMetadata{})
+	for i := 0; i < rt.NumField(); i++ {
+		name := strings.Split(rt.Field(i).Tag.Get("json"), ",")[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		tagged[name] = true
+	}
+
+	known := map[string]bool{}
+	for _, f := range knownASMetadataFields {
+		known[f] = true
+	}
+
+	for name := range tagged {
+		if !known[name] {
+			t.Errorf("struct json field %q is missing from knownASMetadataFields; it would leak into Extra", name)
+		}
+	}
+	for name := range known {
+		if !tagged[name] {
+			t.Errorf("knownASMetadataFields entry %q has no matching struct json tag", name)
+		}
+	}
+}
 
 func TestFetchAuthorizationServerMetadata(t *testing.T) {
 	metadata := AuthorizationServerMetadata{

--- a/oauth/errors.go
+++ b/oauth/errors.go
@@ -98,12 +98,20 @@ func (e *IssuerMismatchError) Error() string { return e.Message }
 func (*IssuerMismatchError) keycardError()   {}
 
 // JWKSDiscoveryError indicates the JWKS URI could not be resolved from the issuer's
-// authorization server metadata.
+// authorization server metadata. Err carries the underlying cause (e.g. a discovery
+// fetch failure or an *IssuerMismatchError) for errors.Is/errors.As.
 type JWKSDiscoveryError struct {
 	Message string
+	Err     error
 }
 
-func (e *JWKSDiscoveryError) Error() string { return e.Message }
+func (e *JWKSDiscoveryError) Error() string {
+	if e.Err != nil {
+		return e.Message + ": " + e.Err.Error()
+	}
+	return e.Message
+}
+func (e *JWKSDiscoveryError) Unwrap() error { return e.Err }
 func (*JWKSDiscoveryError) keycardError()   {}
 
 // JWKSUriValidationError indicates the discovered JWKS URI failed validation, such as
@@ -115,12 +123,21 @@ type JWKSUriValidationError struct {
 func (e *JWKSUriValidationError) Error() string { return e.Message }
 func (*JWKSUriValidationError) keycardError()   {}
 
-// JWKSFetchError indicates the JWKS document could not be fetched or decoded.
+// JWKSFetchError indicates the JWKS document could not be fetched or decoded. Err
+// carries the underlying transport or decode cause (e.g. context.DeadlineExceeded) for
+// errors.Is/errors.As.
 type JWKSFetchError struct {
 	Message string
+	Err     error
 }
 
-func (e *JWKSFetchError) Error() string { return e.Message }
+func (e *JWKSFetchError) Error() string {
+	if e.Err != nil {
+		return e.Message + ": " + e.Err.Error()
+	}
+	return e.Message
+}
+func (e *JWKSFetchError) Unwrap() error { return e.Err }
 func (*JWKSFetchError) keycardError()   {}
 
 // JWKSKeyNotFoundError indicates no key matching the requested key ID was present in

--- a/oauth/errors.go
+++ b/oauth/errors.go
@@ -1,6 +1,19 @@
 package oauth
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// KeycardError is the marker interface implemented by every error this package
+// returns. It lets callers discriminate Keycard SDK errors from other errors with
+// errors.As(err, &kc) where kc is a KeycardError, and pairs with the concrete error
+// types for errors.As to a specific error.
+type KeycardError interface {
+	error
+	keycardError()
+}
 
 // ConfigurationError indicates the SDK was constructed with invalid configuration,
 // such as a verifier built without a trusted issuer or with an unsupported algorithm.
@@ -67,4 +80,77 @@ func (e *InsufficientScopeError) Error() string {
 // ErrorCode returns the OAuth error code for this error.
 func (e *InsufficientScopeError) ErrorCode() string {
 	return "insufficient_scope"
+}
+
+func (*ConfigurationError) keycardError()     {}
+func (*HTTPError) keycardError()              {}
+func (*OAuthError) keycardError()             {}
+func (*InvalidTokenError) keycardError()      {}
+func (*InsufficientScopeError) keycardError() {}
+
+// IssuerMismatchError indicates an authorization server's discovery document reported
+// an issuer that does not match the requested issuer (RFC 8414 section 3.3).
+type IssuerMismatchError struct {
+	Message string
+}
+
+func (e *IssuerMismatchError) Error() string { return e.Message }
+func (*IssuerMismatchError) keycardError()   {}
+
+// JWKSDiscoveryError indicates the JWKS URI could not be resolved from the issuer's
+// authorization server metadata.
+type JWKSDiscoveryError struct {
+	Message string
+}
+
+func (e *JWKSDiscoveryError) Error() string { return e.Message }
+func (*JWKSDiscoveryError) keycardError()   {}
+
+// JWKSUriValidationError indicates the discovered JWKS URI failed validation, such as
+// not sharing an origin with the issuer.
+type JWKSUriValidationError struct {
+	Message string
+}
+
+func (e *JWKSUriValidationError) Error() string { return e.Message }
+func (*JWKSUriValidationError) keycardError()   {}
+
+// JWKSFetchError indicates the JWKS document could not be fetched or decoded.
+type JWKSFetchError struct {
+	Message string
+}
+
+func (e *JWKSFetchError) Error() string { return e.Message }
+func (*JWKSFetchError) keycardError()   {}
+
+// JWKSKeyNotFoundError indicates no key matching the requested key ID was present in
+// the issuer's JWKS.
+type JWKSKeyNotFoundError struct {
+	Message string
+}
+
+func (e *JWKSKeyNotFoundError) Error() string { return e.Message }
+func (*JWKSKeyNotFoundError) keycardError()   {}
+
+// parseOAuthErrorResponse parses an RFC 6749 section 5.2 error response from a token or
+// registration endpoint. It returns an *OAuthError when the body is JSON carrying an
+// "error" field, or nil otherwise so the caller can fall back to a generic HTTP error.
+// It does not close resp.Body.
+func parseOAuthErrorResponse(resp *http.Response) *OAuthError {
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil
+	}
+	code, ok := body["error"].(string)
+	if !ok {
+		return nil
+	}
+	oauthErr := &OAuthError{ErrorCode: code, Message: code}
+	if desc, ok := body["error_description"].(string); ok {
+		oauthErr.Message = desc
+	}
+	if uri, ok := body["error_uri"].(string); ok {
+		oauthErr.ErrorURI = uri
+	}
+	return oauthErr
 }

--- a/oauth/errors_test.go
+++ b/oauth/errors_test.go
@@ -2,6 +2,9 @@ package oauth
 
 import (
 	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -47,5 +50,78 @@ func TestInsufficientScopeError(t *testing.T) {
 	}
 	if err.ErrorCode() != "insufficient_scope" {
 		t.Errorf("got %q", err.ErrorCode())
+	}
+}
+
+func TestKeycardErrorMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"ConfigurationError", &ConfigurationError{Message: "bad config"}, true},
+		{"HTTPError", &HTTPError{Message: "not found", Status: 404}, true},
+		{"OAuthError", &OAuthError{ErrorCode: "invalid_grant", Message: "expired"}, true},
+		{"InvalidTokenError", &InvalidTokenError{Message: "bad signature"}, true},
+		{"InsufficientScopeError", &InsufficientScopeError{Message: "need scope"}, true},
+		{"IssuerMismatchError", &IssuerMismatchError{Message: "mismatch"}, true},
+		{"JWKSFetchError", &JWKSFetchError{Message: "fetch failed"}, true},
+		{"JWKSKeyNotFoundError", &JWKSKeyNotFoundError{Message: "no key"}, true},
+		{"generic error", errors.New("some other error"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var kc KeycardError
+			if got := errors.As(tt.err, &kc); got != tt.want {
+				t.Errorf("errors.As(KeycardError): got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOAuthErrorResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantNil  bool
+		wantCode string
+		wantMsg  string
+		wantURI  string
+	}{
+		{
+			name:     "full RFC 6749 error",
+			body:     `{"error":"invalid_grant","error_description":"token expired","error_uri":"https://e.example/err"}`,
+			wantCode: "invalid_grant",
+			wantMsg:  "token expired",
+			wantURI:  "https://e.example/err",
+		},
+		{
+			name:     "error code only falls back to code as message",
+			body:     `{"error":"server_error"}`,
+			wantCode: "server_error",
+			wantMsg:  "server_error",
+		},
+		{name: "no error field", body: `{"status":"ok"}`, wantNil: true},
+		{name: "invalid json", body: `not json`, wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(tt.body))}
+			got := parseOAuthErrorResponse(resp)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected an *OAuthError, got nil")
+			}
+			if got.ErrorCode != tt.wantCode || got.Message != tt.wantMsg || got.ErrorURI != tt.wantURI {
+				t.Errorf("got {%q,%q,%q}, want {%q,%q,%q}", got.ErrorCode, got.Message, got.ErrorURI, tt.wantCode, tt.wantMsg, tt.wantURI)
+			}
+		})
 	}
 }

--- a/oauth/jwt.go
+++ b/oauth/jwt.go
@@ -17,15 +17,15 @@ const DefaultLeeway = 60 * time.Second
 
 // JWTClaims represents standard JWT claims with optional extra fields.
 type JWTClaims struct {
-	Issuer   string   `json:"iss,omitempty"`
-	Subject  string   `json:"sub,omitempty"`
-	Audience []string `json:"aud,omitempty"`
-	Expiry   int64    `json:"exp,omitempty"`
-	NotBefore int64   `json:"nbf,omitempty"`
-	IssuedAt int64    `json:"iat,omitempty"`
-	JWTID    string   `json:"jti,omitempty"`
-	Scope    string   `json:"scope,omitempty"`
-	ClientID string   `json:"client_id,omitempty"`
+	Issuer    string   `json:"iss,omitempty"`
+	Subject   string   `json:"sub,omitempty"`
+	Audience  []string `json:"aud,omitempty"`
+	Expiry    int64    `json:"exp,omitempty"`
+	NotBefore int64    `json:"nbf,omitempty"`
+	IssuedAt  int64    `json:"iat,omitempty"`
+	JWTID     string   `json:"jti,omitempty"`
+	Scope     string   `json:"scope,omitempty"`
+	ClientID  string   `json:"client_id,omitempty"`
 
 	// Extra holds additional claims not covered by the standard fields.
 	Extra map[string]any `json:"-"`

--- a/oauth/keyring.go
+++ b/oauth/keyring.go
@@ -75,6 +75,7 @@ type jwksKeyringConfig struct {
 	keyTTL       time.Duration
 	discoveryTTL time.Duration
 	fetchTimeout time.Duration
+	maxKeyCache  int
 	httpClient   *http.Client
 }
 
@@ -96,6 +97,13 @@ func WithFetchTimeout(d time.Duration) JWKSOAuthKeyringOption {
 // WithKeyringHTTPClient sets the HTTP client used for JWKS fetches.
 func WithKeyringHTTPClient(c *http.Client) JWKSOAuthKeyringOption {
 	return func(cfg *jwksKeyringConfig) { cfg.httpClient = c }
+}
+
+// WithMaxKeyCacheSize bounds the number of cached public keys. When the cache grows
+// past this size an entry is evicted on the next insert (eviction order is unspecified).
+// A value <= 0 disables the bound. Default: 256.
+func WithMaxKeyCacheSize(n int) JWKSOAuthKeyringOption {
+	return func(cfg *jwksKeyringConfig) { cfg.maxKeyCache = n }
 }
 
 type cacheEntry[T any] struct {
@@ -125,6 +133,7 @@ func NewJWKSOAuthKeyring(opts ...JWKSOAuthKeyringOption) *JWKSOAuthKeyring {
 		keyTTL:       5 * time.Minute,
 		discoveryTTL: 1 * time.Hour,
 		fetchTimeout: 10 * time.Second,
+		maxKeyCache:  256,
 		httpClient:   http.DefaultClient,
 	}
 	for _, opt := range opts {
@@ -179,11 +188,11 @@ func (k *JWKSOAuthKeyring) resolveJWKSURI(ctx context.Context, issuer string) (s
 		metadata, err := FetchAuthorizationServerMetadata(fetchCtx, issuer,
 			WithDiscoveryHTTPClient(k.cfg.httpClient))
 		if err != nil {
-			return nil, fmt.Errorf("discovering JWKS URI for %q: %w", issuer, err)
+			return nil, &JWKSDiscoveryError{Message: fmt.Sprintf("discovering JWKS URI for %q: %v", issuer, err)}
 		}
 
 		if metadata.JWKSURI == "" {
-			return nil, fmt.Errorf("no JWKS URI available for %q", issuer)
+			return nil, &JWKSDiscoveryError{Message: fmt.Sprintf("no JWKS URI available for %q", issuer)}
 		}
 
 		if err := assertSameOrigin(issuer, metadata.JWKSURI); err != nil {
@@ -218,22 +227,22 @@ func (k *JWKSOAuthKeyring) resolveKey(ctx context.Context, issuer, kid, jwksURI,
 
 		resp, err := k.cfg.httpClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("fetching JWKS from %q: %w", jwksURI, err)
+			return nil, &JWKSFetchError{Message: fmt.Sprintf("fetching JWKS from %q: %v", jwksURI, err)}
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("JWKS endpoint %q returned HTTP %d", jwksURI, resp.StatusCode)
+			return nil, &JWKSFetchError{Message: fmt.Sprintf("JWKS endpoint %q returned HTTP %d", jwksURI, resp.StatusCode)}
 		}
 
 		var jwkSet jwkSetJSON
 		if err := json.NewDecoder(resp.Body).Decode(&jwkSet); err != nil {
-			return nil, fmt.Errorf("decoding JWKS: %w", err)
+			return nil, &JWKSFetchError{Message: fmt.Sprintf("decoding JWKS from %q: %v", jwksURI, err)}
 		}
 
 		jwk, err := findKey(jwkSet.Keys, kid)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find key %q of %q: %w", kid, issuer, err)
+			return nil, &JWKSKeyNotFoundError{Message: fmt.Sprintf("key %q not found for issuer %q", kid, issuer)}
 		}
 
 		pubKey, err := importJWK(jwk)
@@ -245,6 +254,21 @@ func (k *JWKSOAuthKeyring) resolveKey(ctx context.Context, issuer, kid, jwksURI,
 		k.keyCache[cacheKey] = cacheEntry[crypto.PublicKey]{
 			value:     pubKey,
 			expiresAt: time.Now().Add(k.cfg.keyTTL),
+		}
+		// Bound the key cache: once over the configured size, evict entries other than
+		// the one just inserted. Eviction order is unspecified (the spec permits this).
+		for k.cfg.maxKeyCache > 0 && len(k.keyCache) > k.cfg.maxKeyCache {
+			evicted := false
+			for old := range k.keyCache {
+				if old != cacheKey {
+					delete(k.keyCache, old)
+					evicted = true
+					break
+				}
+			}
+			if !evicted {
+				break
+			}
 		}
 		k.mu.Unlock()
 
@@ -294,7 +318,7 @@ func assertSameOrigin(issuer, jwksURI string) error {
 	jwksOrigin := jwksURL.Scheme + "://" + jwksURL.Host
 
 	if issuerOrigin != jwksOrigin {
-		return fmt.Errorf("JWKS URI origin %q does not match issuer origin %q for %q", jwksOrigin, issuerOrigin, issuer)
+		return &JWKSUriValidationError{Message: fmt.Sprintf("JWKS URI origin %q does not match issuer origin %q for %q", jwksOrigin, issuerOrigin, issuer)}
 	}
 	return nil
 }

--- a/oauth/keyring.go
+++ b/oauth/keyring.go
@@ -188,7 +188,7 @@ func (k *JWKSOAuthKeyring) resolveJWKSURI(ctx context.Context, issuer string) (s
 		metadata, err := FetchAuthorizationServerMetadata(fetchCtx, issuer,
 			WithDiscoveryHTTPClient(k.cfg.httpClient))
 		if err != nil {
-			return nil, &JWKSDiscoveryError{Message: fmt.Sprintf("discovering JWKS URI for %q: %v", issuer, err)}
+			return nil, &JWKSDiscoveryError{Message: fmt.Sprintf("discovering JWKS URI for %q", issuer), Err: err}
 		}
 
 		if metadata.JWKSURI == "" {
@@ -227,7 +227,7 @@ func (k *JWKSOAuthKeyring) resolveKey(ctx context.Context, issuer, kid, jwksURI,
 
 		resp, err := k.cfg.httpClient.Do(req)
 		if err != nil {
-			return nil, &JWKSFetchError{Message: fmt.Sprintf("fetching JWKS from %q: %v", jwksURI, err)}
+			return nil, &JWKSFetchError{Message: fmt.Sprintf("fetching JWKS from %q", jwksURI), Err: err}
 		}
 		defer resp.Body.Close()
 
@@ -237,7 +237,7 @@ func (k *JWKSOAuthKeyring) resolveKey(ctx context.Context, issuer, kid, jwksURI,
 
 		var jwkSet jwkSetJSON
 		if err := json.NewDecoder(resp.Body).Decode(&jwkSet); err != nil {
-			return nil, &JWKSFetchError{Message: fmt.Sprintf("decoding JWKS from %q: %v", jwksURI, err)}
+			return nil, &JWKSFetchError{Message: fmt.Sprintf("decoding JWKS from %q", jwksURI), Err: err}
 		}
 
 		jwk, err := findKey(jwkSet.Keys, kid)

--- a/oauth/keyring_test.go
+++ b/oauth/keyring_test.go
@@ -38,7 +38,7 @@ func TestJWKSOAuthKeyring_Key(t *testing.T) {
 			json.NewEncoder(w).Encode(jwks)
 		} else if r.URL.Path == "/.well-known/oauth-authorization-server" {
 			metadata := map[string]string{
-				"issuer":   r.URL.Query().Get("issuer"),
+				"issuer":   "http://" + r.Host,
 				"jwks_uri": "http://" + r.Host + "/.well-known/jwks.json",
 			}
 			w.Header().Set("Content-Type", "application/json")

--- a/oauth/keyring_test.go
+++ b/oauth/keyring_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -189,6 +190,80 @@ func TestJWKSOAuthKeyring_Invalidate(t *testing.T) {
 
 	if fetchCount != 2 {
 		t.Errorf("JWKS should be fetched twice after invalidation, got %d", fetchCount)
+	}
+}
+
+// A JWKS fetch failure must preserve its cause so callers can errors.Is the transport
+// error (e.g. a timeout) and errors.As the typed *JWKSFetchError.
+func TestJWKSOAuthKeyring_FetchErrorPreservesCause(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":   "http://" + r.Host,
+				"jwks_uri": "http://" + r.Host + "/.well-known/jwks.json",
+			})
+		case "/.well-known/jwks.json":
+			// Block past the fetch timeout so the JWKS fetch context expires.
+			select {
+			case <-time.After(2 * time.Second):
+			case <-r.Context().Done():
+			}
+		}
+	}))
+	defer server.Close()
+
+	keyring := NewJWKSOAuthKeyring(
+		WithFetchTimeout(100*time.Millisecond),
+		WithKeyringHTTPClient(server.Client()),
+	)
+
+	_, err := keyring.Key(context.Background(), server.URL, "test-key-1")
+	if err == nil {
+		t.Fatal("expected a fetch error")
+	}
+
+	var fetchErr *JWKSFetchError
+	if !errors.As(err, &fetchErr) {
+		t.Errorf("errors.As(*JWKSFetchError): got %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(context.DeadlineExceeded): cause was dropped, got %v", err)
+	}
+}
+
+// A discovery failure during key resolution must preserve its cause so a nested
+// *IssuerMismatchError remains reachable via errors.As, matching a direct discovery call.
+func TestJWKSOAuthKeyring_DiscoveryErrorPreservesIssuerMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			w.Header().Set("Content-Type", "application/json")
+			// Report a different issuer than requested to trigger an IssuerMismatchError.
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":   "https://imposter.example.com",
+				"jwks_uri": "http://" + r.Host + "/.well-known/jwks.json",
+			})
+		}
+	}))
+	defer server.Close()
+
+	keyring := NewJWKSOAuthKeyring(
+		WithKeyringHTTPClient(server.Client()),
+	)
+
+	_, err := keyring.Key(context.Background(), server.URL, "test-key-1")
+	if err == nil {
+		t.Fatal("expected a discovery error")
+	}
+
+	var discErr *JWKSDiscoveryError
+	if !errors.As(err, &discErr) {
+		t.Errorf("errors.As(*JWKSDiscoveryError): got %v", err)
+	}
+	var mismatch *IssuerMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Errorf("errors.As(*IssuerMismatchError): nested cause was dropped, got %v", err)
 	}
 }
 

--- a/oauth/registration.go
+++ b/oauth/registration.go
@@ -100,18 +100,8 @@ func RegisterClient(ctx context.Context, issuer string, req RegistrationRequest,
 
 	// RFC 7591 §3.2.1 returns 201 Created; some servers return 200.
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		var errBody map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
-			if errCode, ok := errBody["error"].(string); ok {
-				oauthErr := &OAuthError{ErrorCode: errCode, Message: errCode}
-				if desc, ok := errBody["error_description"].(string); ok {
-					oauthErr.Message = desc
-				}
-				if uri, ok := errBody["error_uri"].(string); ok {
-					oauthErr.ErrorURI = uri
-				}
-				return nil, oauthErr
-			}
+		if oauthErr := parseOAuthErrorResponse(resp); oauthErr != nil {
+			return nil, oauthErr
 		}
 		return nil, &HTTPError{Message: "client registration failed", Status: resp.StatusCode}
 	}

--- a/oauth/token_exchange.go
+++ b/oauth/token_exchange.go
@@ -31,6 +31,7 @@ type TokenResponse struct {
 	TokenType       string   `json:"token_type"`
 	ExpiresIn       int      `json:"expires_in,omitempty"`
 	RefreshToken    string   `json:"refresh_token,omitempty"`
+	IDToken         string   `json:"id_token,omitempty"`
 	Scope           []string `json:"scope,omitempty"`
 	IssuedTokenType string   `json:"issued_token_type,omitempty"`
 	UserID          string   `json:"user_id,omitempty"`
@@ -121,22 +122,8 @@ func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, req TokenExchan
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		var errBody map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil {
-			if errCode, ok := errBody["error"].(string); ok {
-				oauthErr := &OAuthError{
-					ErrorCode: errCode,
-				}
-				if desc, ok := errBody["error_description"].(string); ok {
-					oauthErr.Message = desc
-				} else {
-					oauthErr.Message = errCode
-				}
-				if uri, ok := errBody["error_uri"].(string); ok {
-					oauthErr.ErrorURI = uri
-				}
-				return nil, oauthErr
-			}
+		if oauthErr := parseOAuthErrorResponse(resp); oauthErr != nil {
+			return nil, oauthErr
 		}
 		return nil, fmt.Errorf("token exchange failed (HTTP %d)", resp.StatusCode)
 	}
@@ -234,7 +221,7 @@ func deserializeTokenResponse(resp *http.Response) (*TokenResponse, error) {
 
 	tokenType, _ := raw["token_type"].(string)
 	if tokenType == "" {
-		tokenType = "bearer"
+		tokenType = "Bearer"
 	}
 
 	result := &TokenResponse{
@@ -247,6 +234,9 @@ func deserializeTokenResponse(resp *http.Response) (*TokenResponse, error) {
 	}
 	if v, ok := raw["refresh_token"].(string); ok {
 		result.RefreshToken = v
+	}
+	if v, ok := raw["id_token"].(string); ok {
+		result.IDToken = v
 	}
 	if v, ok := raw["issued_token_type"].(string); ok {
 		result.IssuedTokenType = v


### PR DESCRIPTION
## What

The oauth-layer items of ECO-94 (Go conformance polish), aligning with the spec divergence tables and Python/TS parity. Four cohesive changes plus a deduplication.

### 1. Authorization-server discovery (`oauth/discovery.go`)
- Validate the response `issuer` matches the requested issuer (RFC 8414 §3.3, trailing slash ignored); a mismatch returns a typed `IssuerMismatchError`.
- Preserve fields beyond the standard set on `AuthorizationServerMetadata.Extra` for forward compatibility.

### 2. Token-exchange response (`oauth/token_exchange.go`)
- Add `TokenResponse.IDToken` (`id_token`).
- Default `token_type` to `Bearer` (RFC 6750 casing) instead of `bearer`. Client-credentials and authorization-code inherit via the shared `deserializeTokenResponse`.

### 3. JWKS keyring (`oauth/keyring.go`)
- Bound the key cache with `WithMaxKeyCacheSize` (default 256) and evict on overflow (eviction order unspecified, per spec).
- Return typed `JWKSDiscoveryError`, `JWKSUriValidationError`, `JWKSFetchError`, `JWKSKeyNotFoundError` at the resolve/fetch sites instead of generic errors.

### 4. Error model (`oauth/errors.go` + 4 call sites)
- Add the `KeycardError` marker interface so callers can discriminate SDK errors via `errors.As`.
- Replace the RFC 6749 §5.2 error parsing duplicated across token-exchange, client-credentials, authorization-code, and registration with one `parseOAuthErrorResponse` helper.

## Tests

- `errors_test.go`: marker interface across all error types; `parseOAuthErrorResponse` table.
- `conformance_test.go`: issuer mismatch / trailing-slash / unknown-fields-preserved; `token_type` default + `id_token`; bounded key cache; typed JWKS errors (fetch / key-not-found / uri-validation).
- Updated two existing mocks that returned a non-matching issuer (a real AS reports its own URL).
- `go build` / `go vet` / `go test -race ./...` / `go build ./examples/...` all clean.

Part of ECO-94 (the metadata-endpoints item is in #21; remaining gated items B2/B4 follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
