### PR TITLE
feat(mcp)!: validate application credential construction and type EKS runtime errors (ECO-94)

### DIFF
--- a/examples/delegated-access/main.go
+++ b/examples/delegated-access/main.go
@@ -25,9 +25,14 @@ func main() {
 		log.Fatal("KEYCARD_ZONE_URL, KEYCARD_CLIENT_ID, and KEYCARD_CLIENT_SECRET are required")
 	}
 
+	credential, err := mcp.NewClientSecret(clientID, clientSecret)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	authProvider, err := mcp.NewAuthProvider(
 		mcp.WithZoneURL(zoneURL),
-		mcp.WithApplicationCredential(mcp.NewClientSecret(clientID, clientSecret)),
+		mcp.WithApplicationCredential(credential),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/multi-zone/main.go
+++ b/examples/multi-zone/main.go
@@ -33,10 +33,13 @@ func main() {
 
 	// One credential carrying both zones' client credentials, keyed by zone URL. It is
 	// self-describing: holding more than one zone makes the provider multi-zone.
-	credential := mcp.NewMultiZoneClientSecret(map[string]mcp.ClientAuth{
+	credential, err := mcp.NewMultiZoneClientSecret(map[string]mcp.ClientAuth{
 		aURL: {ClientID: os.Getenv("KEYCARD_ZONE_A_CLIENT_ID"), ClientSecret: os.Getenv("KEYCARD_ZONE_A_CLIENT_SECRET")},
 		bURL: {ClientID: os.Getenv("KEYCARD_ZONE_B_CLIENT_ID"), ClientSecret: os.Getenv("KEYCARD_ZONE_B_CLIENT_SECRET")},
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// The verifier trusts tokens from either zone; the token's iss selects the zone and
 	// its JWKS. A token from any other issuer is rejected.

--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -52,16 +52,35 @@ type ClientSecretCredential struct {
 	zones        map[string]ClientAuth // non-nil only for a multi-zone credential
 }
 
-// NewClientSecret creates a single-zone ClientSecretCredential.
-func NewClientSecret(clientID, clientSecret string) *ClientSecretCredential {
-	return &ClientSecretCredential{clientID: clientID, clientSecret: clientSecret}
+// NewClientSecret creates a single-zone ClientSecretCredential. It returns a
+// ClientSecretConfigurationError if the client_id or client_secret is empty.
+func NewClientSecret(clientID, clientSecret string) (*ClientSecretCredential, error) {
+	if strings.TrimSpace(clientID) == "" {
+		return nil, &ClientSecretConfigurationError{Message: "client_id must not be empty"}
+	}
+	if strings.TrimSpace(clientSecret) == "" {
+		return nil, &ClientSecretConfigurationError{Message: "client_secret must not be empty"}
+	}
+	return &ClientSecretCredential{clientID: clientID, clientSecret: clientSecret}, nil
 }
 
 // NewMultiZoneClientSecret creates a multi-zone ClientSecretCredential from a map of
 // zone issuer URL to that zone's client credentials. The credential is self-describing:
-// holding zone entries marks it multi-zone.
-func NewMultiZoneClientSecret(zones map[string]ClientAuth) *ClientSecretCredential {
-	return &ClientSecretCredential{zones: zones}
+// holding zone entries marks it multi-zone. It returns a ClientSecretConfigurationError
+// if the map is empty or any entry has an empty issuer, client_id, or client_secret.
+func NewMultiZoneClientSecret(zones map[string]ClientAuth) (*ClientSecretCredential, error) {
+	if len(zones) == 0 {
+		return nil, &ClientSecretConfigurationError{Message: "multi-zone credential requires at least one zone"}
+	}
+	for issuer, auth := range zones {
+		if strings.TrimSpace(issuer) == "" {
+			return nil, &ClientSecretConfigurationError{Message: "multi-zone credential has an empty zone issuer"}
+		}
+		if strings.TrimSpace(auth.ClientID) == "" || strings.TrimSpace(auth.ClientSecret) == "" {
+			return nil, &ClientSecretConfigurationError{Message: fmt.Sprintf("zone %q is missing client_id or client_secret", issuer)}
+		}
+	}
+	return &ClientSecretCredential{zones: zones}, nil
 }
 
 // Auth returns the basic-auth credentials for the given zone issuer. A single-zone
@@ -306,12 +325,12 @@ func (e *EKSWorkloadIdentityCredential) Auth(_ string) *ClientAuth {
 func (e *EKSWorkloadIdentityCredential) PrepareTokenExchangeRequest(_ context.Context, subjectToken, resource string, _ *PrepareOptions) (*oauth.TokenExchangeRequest, error) {
 	data, err := os.ReadFile(e.tokenFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("reading EKS token from %q: %w", e.tokenFilePath, err)
+		return nil, &EKSWorkloadIdentityRuntimeError{Message: fmt.Sprintf("reading EKS token from %q: %v", e.tokenFilePath, err)}
 	}
 
 	eksToken := strings.TrimSpace(string(data))
 	if eksToken == "" {
-		return nil, fmt.Errorf("EKS token file is empty: %s", e.tokenFilePath)
+		return nil, &EKSWorkloadIdentityRuntimeError{Message: fmt.Sprintf("EKS token file is empty: %s", e.tokenFilePath)}
 	}
 
 	return &oauth.TokenExchangeRequest{

--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -53,7 +53,10 @@ type ClientSecretCredential struct {
 }
 
 // NewClientSecret creates a single-zone ClientSecretCredential. It returns a
-// ClientSecretConfigurationError if the client_id or client_secret is empty.
+// ClientSecretConfigurationError if the client_id or client_secret is empty (or only
+// whitespace). The values are used verbatim for HTTP basic auth, so callers should pass
+// them without surrounding whitespace; a padded client_id otherwise produces an opaque
+// invalid_client at the token endpoint.
 func NewClientSecret(clientID, clientSecret string) (*ClientSecretCredential, error) {
 	if strings.TrimSpace(clientID) == "" {
 		return nil, &ClientSecretConfigurationError{Message: "client_id must not be empty"}
@@ -304,7 +307,8 @@ func NewEKSWorkloadIdentity(opts ...EKSWorkloadIdentityOption) (*EKSWorkloadIden
 	data, err := os.ReadFile(tokenFilePath)
 	if err != nil {
 		return nil, &EKSWorkloadIdentityConfigurationError{
-			Message: fmt.Sprintf("error reading token file %q: %v", tokenFilePath, err),
+			Message: fmt.Sprintf("error reading token file %q", tokenFilePath),
+			Err:     err,
 		}
 	}
 	if len(strings.TrimSpace(string(data))) == 0 {
@@ -325,7 +329,7 @@ func (e *EKSWorkloadIdentityCredential) Auth(_ string) *ClientAuth {
 func (e *EKSWorkloadIdentityCredential) PrepareTokenExchangeRequest(_ context.Context, subjectToken, resource string, _ *PrepareOptions) (*oauth.TokenExchangeRequest, error) {
 	data, err := os.ReadFile(e.tokenFilePath)
 	if err != nil {
-		return nil, &EKSWorkloadIdentityRuntimeError{Message: fmt.Sprintf("reading EKS token from %q: %v", e.tokenFilePath, err)}
+		return nil, &EKSWorkloadIdentityRuntimeError{Message: fmt.Sprintf("reading EKS token from %q", e.tokenFilePath), Err: err}
 	}
 
 	eksToken := strings.TrimSpace(string(data))

--- a/mcp/credentials_test.go
+++ b/mcp/credentials_test.go
@@ -94,6 +94,13 @@ func TestNewEKSWorkloadIdentity_ConfigErrorOnMissingFile(t *testing.T) {
 	if !errors.As(err, &cfgErr) {
 		t.Fatalf("error: got %v, want EKSWorkloadIdentityConfigurationError", err)
 	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("errors.Is(os.ErrNotExist): cause was dropped, got %v", err)
+	}
+	var runtimeErr *EKSWorkloadIdentityRuntimeError
+	if errors.As(err, &runtimeErr) {
+		t.Error("construction failure should not be an EKSWorkloadIdentityRuntimeError")
+	}
 }
 
 func TestEKSWorkloadIdentity_RuntimeErrorAfterConstruction(t *testing.T) {
@@ -101,8 +108,9 @@ func TestEKSWorkloadIdentity_RuntimeErrorAfterConstruction(t *testing.T) {
 	// (e.g. rotated away by the platform). A read at request time must surface a runtime
 	// error, distinct from the construction-time configuration error.
 	cases := []struct {
-		name    string
-		corrupt func(t *testing.T, path string)
+		name              string
+		corrupt           func(t *testing.T, path string)
+		wantUnwrapMissing bool // the read returns os.ErrNotExist (vs an empty-but-present file)
 	}{
 		{
 			name: "file removed",
@@ -111,6 +119,7 @@ func TestEKSWorkloadIdentity_RuntimeErrorAfterConstruction(t *testing.T) {
 					t.Fatalf("removing token file: %v", err)
 				}
 			},
+			wantUnwrapMissing: true,
 		},
 		{
 			name: "file emptied",
@@ -119,6 +128,7 @@ func TestEKSWorkloadIdentity_RuntimeErrorAfterConstruction(t *testing.T) {
 					t.Fatalf("emptying token file: %v", err)
 				}
 			},
+			wantUnwrapMissing: false,
 		},
 	}
 
@@ -140,6 +150,13 @@ func TestEKSWorkloadIdentity_RuntimeErrorAfterConstruction(t *testing.T) {
 			var runtimeErr *EKSWorkloadIdentityRuntimeError
 			if !errors.As(err, &runtimeErr) {
 				t.Fatalf("error: got %v, want EKSWorkloadIdentityRuntimeError", err)
+			}
+			var cfgErr *EKSWorkloadIdentityConfigurationError
+			if errors.As(err, &cfgErr) {
+				t.Error("a read failure at request time should not be an EKSWorkloadIdentityConfigurationError")
+			}
+			if tc.wantUnwrapMissing && !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("errors.Is(os.ErrNotExist): cause was dropped, got %v", err)
 			}
 		})
 	}

--- a/mcp/credentials_test.go
+++ b/mcp/credentials_test.go
@@ -1,0 +1,169 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewClientSecret_RejectsEmpty(t *testing.T) {
+	cases := []struct {
+		name         string
+		clientID     string
+		clientSecret string
+		wantErr      bool
+	}{
+		{name: "valid", clientID: "id", clientSecret: "secret", wantErr: false},
+		{name: "empty client_id", clientID: "", clientSecret: "secret", wantErr: true},
+		{name: "empty client_secret", clientID: "id", clientSecret: "", wantErr: true},
+		{name: "whitespace client_id", clientID: "   ", clientSecret: "secret", wantErr: true},
+		{name: "whitespace client_secret", clientID: "id", clientSecret: "\t", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cred, err := NewClientSecret(tc.clientID, tc.clientSecret)
+			if tc.wantErr {
+				var cfgErr *ClientSecretConfigurationError
+				if !errors.As(err, &cfgErr) {
+					t.Fatalf("error: got %v, want ClientSecretConfigurationError", err)
+				}
+				if cred != nil {
+					t.Errorf("credential: got %v, want nil on error", cred)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cred == nil {
+				t.Fatal("credential: got nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestNewMultiZoneClientSecret_RejectsInvalid(t *testing.T) {
+	valid := ClientAuth{ClientID: "id", ClientSecret: "secret"}
+
+	cases := []struct {
+		name    string
+		zones   map[string]ClientAuth
+		wantErr bool
+	}{
+		{name: "valid single zone", zones: map[string]ClientAuth{"https://a.example.com": valid}, wantErr: false},
+		{name: "valid two zones", zones: map[string]ClientAuth{"https://a.example.com": valid, "https://b.example.com": valid}, wantErr: false},
+		{name: "nil map", zones: nil, wantErr: true},
+		{name: "empty map", zones: map[string]ClientAuth{}, wantErr: true},
+		{name: "empty issuer", zones: map[string]ClientAuth{"  ": valid}, wantErr: true},
+		{name: "missing client_id", zones: map[string]ClientAuth{"https://a.example.com": {ClientSecret: "secret"}}, wantErr: true},
+		{name: "missing client_secret", zones: map[string]ClientAuth{"https://a.example.com": {ClientID: "id"}}, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cred, err := NewMultiZoneClientSecret(tc.zones)
+			if tc.wantErr {
+				var cfgErr *ClientSecretConfigurationError
+				if !errors.As(err, &cfgErr) {
+					t.Fatalf("error: got %v, want ClientSecretConfigurationError", err)
+				}
+				if cred != nil {
+					t.Errorf("credential: got %v, want nil on error", cred)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(cred.Zones()) != len(tc.zones) {
+				t.Errorf("zones: got %d, want %d", len(cred.Zones()), len(tc.zones))
+			}
+		})
+	}
+}
+
+func TestNewEKSWorkloadIdentity_ConfigErrorOnMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	_, err := NewEKSWorkloadIdentity(WithTokenFilePath(missing))
+
+	var cfgErr *EKSWorkloadIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want EKSWorkloadIdentityConfigurationError", err)
+	}
+}
+
+func TestEKSWorkloadIdentity_RuntimeErrorAfterConstruction(t *testing.T) {
+	// The credential is valid at construction, then the token file is removed or emptied
+	// (e.g. rotated away by the platform). A read at request time must surface a runtime
+	// error, distinct from the construction-time configuration error.
+	cases := []struct {
+		name    string
+		corrupt func(t *testing.T, path string)
+	}{
+		{
+			name: "file removed",
+			corrupt: func(t *testing.T, path string) {
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("removing token file: %v", err)
+				}
+			},
+		},
+		{
+			name: "file emptied",
+			corrupt: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte("   \n"), 0o600); err != nil {
+					t.Fatalf("emptying token file: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "eks-token")
+			if err := os.WriteFile(path, []byte("initial-token"), 0o600); err != nil {
+				t.Fatalf("writing token file: %v", err)
+			}
+
+			cred, err := NewEKSWorkloadIdentity(WithTokenFilePath(path))
+			if err != nil {
+				t.Fatalf("constructing credential: %v", err)
+			}
+
+			tc.corrupt(t, path)
+
+			_, err = cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+			var runtimeErr *EKSWorkloadIdentityRuntimeError
+			if !errors.As(err, &runtimeErr) {
+				t.Fatalf("error: got %v, want EKSWorkloadIdentityRuntimeError", err)
+			}
+		})
+	}
+}
+
+func TestEKSWorkloadIdentity_PreparesRequestWhenTokenPresent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "eks-token")
+	if err := os.WriteFile(path, []byte("eks-pod-token\n"), 0o600); err != nil {
+		t.Fatalf("writing token file: %v", err)
+	}
+
+	cred, err := NewEKSWorkloadIdentity(WithTokenFilePath(path))
+	if err != nil {
+		t.Fatalf("constructing credential: %v", err)
+	}
+
+	req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+	if err != nil {
+		t.Fatalf("preparing request: %v", err)
+	}
+	if req.ClientAssertion != "eks-pod-token" {
+		t.Errorf("client assertion: got %q, want trimmed token", req.ClientAssertion)
+	}
+	if req.ClientAssertionType != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("client assertion type: got %q", req.ClientAssertionType)
+	}
+}

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -22,25 +22,41 @@ func (e *AuthProviderConfigurationError) Error() string {
 }
 
 // EKSWorkloadIdentityConfigurationError indicates invalid EKS workload identity configuration
-// detected at construction (e.g. no token file path, or the file is missing or empty).
+// detected at construction (e.g. no token file path, or the file is missing or empty). Err
+// carries the underlying cause (e.g. os.ErrNotExist or os.ErrPermission from reading the
+// token file) for errors.Is/errors.As, and is nil when there is no underlying error.
 type EKSWorkloadIdentityConfigurationError struct {
 	Message string
+	Err     error
 }
 
 func (e *EKSWorkloadIdentityConfigurationError) Error() string {
+	if e.Err != nil {
+		return e.Message + ": " + e.Err.Error()
+	}
 	return e.Message
 }
+
+func (e *EKSWorkloadIdentityConfigurationError) Unwrap() error { return e.Err }
 
 // EKSWorkloadIdentityRuntimeError indicates the EKS token could not be read at request
 // time (e.g. the token file was rotated away or emptied after construction). It is
 // distinct from EKSWorkloadIdentityConfigurationError, which is a construction-time fault.
+// Err carries the underlying read cause (e.g. os.ErrNotExist or os.ErrPermission) for
+// errors.Is/errors.As, and is nil when there is no underlying error (e.g. an empty token).
 type EKSWorkloadIdentityRuntimeError struct {
 	Message string
+	Err     error
 }
 
 func (e *EKSWorkloadIdentityRuntimeError) Error() string {
+	if e.Err != nil {
+		return e.Message + ": " + e.Err.Error()
+	}
 	return e.Message
 }
+
+func (e *EKSWorkloadIdentityRuntimeError) Unwrap() error { return e.Err }
 
 // ClientSecretConfigurationError indicates a ClientSecretCredential was constructed with
 // invalid configuration, such as an empty client_id or client_secret, or an empty

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -21,11 +21,34 @@ func (e *AuthProviderConfigurationError) Error() string {
 	return e.Message
 }
 
-// EKSWorkloadIdentityConfigurationError indicates invalid EKS workload identity configuration.
+// EKSWorkloadIdentityConfigurationError indicates invalid EKS workload identity configuration
+// detected at construction (e.g. no token file path, or the file is missing or empty).
 type EKSWorkloadIdentityConfigurationError struct {
 	Message string
 }
 
 func (e *EKSWorkloadIdentityConfigurationError) Error() string {
+	return e.Message
+}
+
+// EKSWorkloadIdentityRuntimeError indicates the EKS token could not be read at request
+// time (e.g. the token file was rotated away or emptied after construction). It is
+// distinct from EKSWorkloadIdentityConfigurationError, which is a construction-time fault.
+type EKSWorkloadIdentityRuntimeError struct {
+	Message string
+}
+
+func (e *EKSWorkloadIdentityRuntimeError) Error() string {
+	return e.Message
+}
+
+// ClientSecretConfigurationError indicates a ClientSecretCredential was constructed with
+// invalid configuration, such as an empty client_id or client_secret, or an empty
+// multi-zone map.
+type ClientSecretConfigurationError struct {
+	Message string
+}
+
+func (e *ClientSecretConfigurationError) Error() string {
 	return e.Message
 }

--- a/mcp/multizone_test.go
+++ b/mcp/multizone_test.go
@@ -16,6 +16,28 @@ import (
 	"github.com/keycardai/credentials-go/oauth"
 )
 
+// mustMultiZone builds a multi-zone client-secret credential and fails the test if
+// construction is rejected.
+func mustMultiZone(t *testing.T, zones map[string]ClientAuth) *ClientSecretCredential {
+	t.Helper()
+	cred, err := NewMultiZoneClientSecret(zones)
+	if err != nil {
+		t.Fatalf("NewMultiZoneClientSecret: %v", err)
+	}
+	return cred
+}
+
+// mustClientSecret builds a single-zone client-secret credential and fails the test if
+// construction is rejected.
+func mustClientSecret(t *testing.T, clientID, clientSecret string) *ClientSecretCredential {
+	t.Helper()
+	cred, err := NewClientSecret(clientID, clientSecret)
+	if err != nil {
+		t.Fatalf("NewClientSecret: %v", err)
+	}
+	return cred
+}
+
 // zoneServer is a fake authorization server for one zone: it serves discovery and a
 // /token endpoint that records the Basic-auth client id it received, so tests can
 // assert that the exchange used the right zone's credential.
@@ -104,7 +126,7 @@ func serveWithToken(h http.Handler, token string) *httptest.ResponseRecorder {
 
 // Spec row 1: a multi-zone credential is self-describing and resolves per zone.
 func TestMultiZoneClientSecret_ResolvesPerZone(t *testing.T) {
-	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+	cred := mustMultiZone(t, map[string]ClientAuth{
 		"https://zone-a.keycard.cloud": {ClientID: "client-a", ClientSecret: "secret-a"},
 		"https://zone-b.keycard.cloud": {ClientID: "client-b", ClientSecret: "secret-b"},
 	})
@@ -129,7 +151,7 @@ func TestAuthProvider_ExchangeRoutesToZoneCredential(t *testing.T) {
 	zoneA := newZoneServer(t)
 	zoneB := newZoneServer(t)
 
-	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+	cred := mustMultiZone(t, map[string]ClientAuth{
 		zoneA.URL: {ClientID: "client-a", ClientSecret: "secret-a"},
 		zoneB.URL: {ClientID: "client-b", ClientSecret: "secret-b"},
 	})
@@ -162,7 +184,7 @@ func TestAuthProvider_ExchangeRoutesToZoneCredential(t *testing.T) {
 
 // Spec row 5: a resolved zone with no configured credential fails closed.
 func TestAuthProvider_MultiZoneUnknownZoneFailsClosed(t *testing.T) {
-	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+	cred := mustMultiZone(t, map[string]ClientAuth{
 		"https://zone-a.keycard.cloud": {ClientID: "client-a", ClientSecret: "secret-a"},
 	})
 	provider, err := NewAuthProvider(WithApplicationCredential(cred))
@@ -178,7 +200,7 @@ func TestAuthProvider_MultiZoneUnknownZoneFailsClosed(t *testing.T) {
 
 // Spec row 4: a request whose zone cannot be resolved fails closed.
 func TestAuthProvider_MultiZoneUnresolvedZoneFailsClosed(t *testing.T) {
-	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+	cred := mustMultiZone(t, map[string]ClientAuth{
 		"https://zone-a.keycard.cloud": {ClientID: "client-a", ClientSecret: "secret-a"},
 	})
 	provider, err := NewAuthProvider(WithApplicationCredential(cred))
@@ -209,7 +231,7 @@ func TestAuthProvider_GrantRoutesByTokenIssuer(t *testing.T) {
 		t.Fatalf("NewJWTOAuthTokenVerifier: %v", err)
 	}
 
-	cred := NewMultiZoneClientSecret(map[string]ClientAuth{
+	cred := mustMultiZone(t, map[string]ClientAuth{
 		zoneA.URL: {ClientID: "client-a", ClientSecret: "secret-a"},
 		zoneB.URL: {ClientID: "client-b", ClientSecret: "secret-b"},
 	})

--- a/mcp/provider_test.go
+++ b/mcp/provider_test.go
@@ -220,7 +220,7 @@ func TestAuthProvider_ExchangeTokens(t *testing.T) {
 
 	provider, err := NewAuthProvider(
 		WithZoneURL(tokenServer.URL),
-		WithApplicationCredential(NewClientSecret("client-id", "client-secret")),
+		WithApplicationCredential(mustClientSecret(t, "client-id", "client-secret")),
 	)
 	if err != nil {
 		t.Fatalf("creating provider: %v", err)


### PR DESCRIPTION
## What

Tightens construction and runtime error handling for the `mcp` application credentials, part of the ECO-94 conformance polish.

- **ClientSecret construction validates inputs.** `NewClientSecret` and `NewMultiZoneClientSecret` now return `(*ClientSecretCredential, error)` and reject an empty `client_id`, empty `client_secret`, an empty zone map, or a zone entry missing its issuer or credentials. They return a typed `ClientSecretConfigurationError`.
- **EKS read failures are a distinct, typed runtime error.** `EKSWorkloadIdentityCredential.PrepareTokenExchangeRequest` returns the new `EKSWorkloadIdentityRuntimeError` when the token file cannot be read or is empty at request time, separate from the construction-time `EKSWorkloadIdentityConfigurationError`.

## Why

The spec's application-credential contract requires construction to fail loudly on invalid input rather than producing a credential that fails opaquely mid-exchange. Previously an empty `client_id`/`client_secret` (or an empty multi-zone map) constructed silently and only surfaced as an upstream `invalid_client` much later. Splitting the EKS construction error from the read-time error lets callers distinguish a misconfiguration (wrong path, no token at boot) from a token that was valid at boot and later rotated away.

This matches the Python/TS surface, where credential constructors validate and raise typed configuration errors.

## Breaking change

`NewClientSecret` and `NewMultiZoneClientSecret` now return `(*ClientSecretCredential, error)`. Callers must handle the error:

```go
cred, err := mcp.NewClientSecret(clientID, clientSecret)
if err != nil {
    return err
}
```

The two affected examples (`delegated-access`, `multi-zone`) are updated in this PR.

## Scope note

The WebIdentity construction tightening from the ECO-94 checklist (require `client_id` + `token_endpoint`, change the default storage dir with a legacy fallback, add `audience_config`) is intentionally left to a follow-up to keep this PR focused on the ClientSecret/EKS items.

## Verify

- `go build ./... ./examples/...`
- `go vet ./...`
- `go test -race -count=1 ./...` (new `mcp/credentials_test.go` covers empty-input rejection, multi-zone invalid entries, EKS config-vs-runtime error split, and the happy path)
- `gofmt -l` clean on changed files

Linear: ECO-94 (ticks the ClientSecret + EKS conformance boxes).