### PR TITLE
feat(a2a): add agent-to-agent delegation client (ECO-95)

### DIFF
--- a/a2a/client.go
+++ b/a2a/client.go
@@ -42,6 +42,7 @@ type DelegationClient struct {
 	discovery       *ServiceDiscovery
 	httpClient      *http.Client
 	protocolVersion string
+	invokeTimeout   time.Duration
 }
 
 // DelegationOption configures a DelegationClient.
@@ -51,12 +52,22 @@ type delegationConfig struct {
 	httpClient      *http.Client
 	discovery       *ServiceDiscovery
 	protocolVersion string
+	invokeTimeout   time.Duration
 }
 
-// WithHTTPClient sets the HTTP client used for both the token exchange and the agent
-// invocation. The default client has a 30 second timeout.
+// WithHTTPClient sets the HTTP client used for the token exchange and the agent
+// invocation. Unless a ServiceDiscovery is supplied via WithServiceDiscovery, this
+// client also governs agent-card discovery. The default client has a 30 second timeout.
 func WithHTTPClient(c *http.Client) DelegationOption {
 	return func(cfg *delegationConfig) { cfg.httpClient = c }
+}
+
+// WithInvokeTimeout bounds the total time for a single Invoke call (discovery, token
+// exchange, and invocation combined). It is enforced via the context, independent of any
+// HTTP client timeout, so it still applies when a caller supplies an http.Client with no
+// Timeout of its own. Defaults to 30 seconds; a value <= 0 disables it.
+func WithInvokeTimeout(d time.Duration) DelegationOption {
+	return func(cfg *delegationConfig) { cfg.invokeTimeout = d }
 }
 
 // WithServiceDiscovery supplies a shared ServiceDiscovery (for a shared agent-card
@@ -84,7 +95,10 @@ func NewDelegationClient(issuer, clientID, clientSecret string, opts ...Delegati
 		return nil, &ConfigurationError{Message: "client_id and client_secret must not be empty"}
 	}
 
-	cfg := delegationConfig{protocolVersion: defaultProtocolVersion}
+	cfg := delegationConfig{
+		protocolVersion: defaultProtocolVersion,
+		invokeTimeout:   defaultInvokeTimeout,
+	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -96,7 +110,12 @@ func NewDelegationClient(issuer, clientID, clientSecret string, opts ...Delegati
 
 	discovery := cfg.discovery
 	if discovery == nil {
-		discovery = NewServiceDiscovery()
+		var dopts []DiscoveryOption
+		if cfg.httpClient != nil {
+			// A caller-supplied client governs discovery too (e.g. a shared proxy).
+			dopts = append(dopts, WithDiscoveryHTTPClient(cfg.httpClient))
+		}
+		discovery = NewServiceDiscovery(dopts...)
 	}
 
 	exchange := oauth.NewTokenExchangeClient(issuer,
@@ -109,6 +128,7 @@ func NewDelegationClient(issuer, clientID, clientSecret string, opts ...Delegati
 		discovery:       discovery,
 		httpClient:      httpClient,
 		protocolVersion: cfg.protocolVersion,
+		invokeTimeout:   cfg.invokeTimeout,
 	}, nil
 }
 
@@ -122,6 +142,12 @@ func NewDelegationClient(issuer, clientID, clientSecret string, opts ...Delegati
 func (c *DelegationClient) Invoke(ctx context.Context, target, subjectToken string, msg Message) (*Result, error) {
 	if strings.TrimSpace(subjectToken) == "" {
 		return nil, &ConfigurationError{Message: "subject_token must not be empty"}
+	}
+
+	if c.invokeTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.invokeTimeout)
+		defer cancel()
 	}
 
 	card, err := c.discovery.GetCard(ctx, target)
@@ -221,6 +247,9 @@ func (c *DelegationClient) invoke(ctx context.Context, endpoint, bearer string, 
 	}
 	if rpcResp.Result == nil {
 		return Message{}, &InvocationError{Message: "agent response carried neither result nor error"}
+	}
+	if rpcResp.Result.Message.MessageID == "" && len(rpcResp.Result.Message.Parts) == 0 {
+		return Message{}, &InvocationError{Message: "agent response carried an empty result message"}
 	}
 
 	return rpcResp.Result.Message, nil

--- a/a2a/client.go
+++ b/a2a/client.go
@@ -1,0 +1,227 @@
+// Package a2a implements Keycard's agent-to-agent (A2A) delegation contract: one
+// agent service calling another on the user's behalf, carrying the user's identity
+// through every hop.
+//
+// A delegated call is three steps. It discovers the target agent's card from
+// <target>/.well-known/agent-card.json, performs an RFC 8693 token exchange (the
+// inbound user token is the subject and the calling agent's own credential
+// authenticates the exchange) to obtain a token scoped to the target, and invokes the
+// target's A2A JSON-RPC endpoint with that token as the bearer credential. The user
+// remains the subject at each hop; the authorization server records the calling agent
+// in the token's act chain for audit.
+//
+// This package implements the delegation contract only. Hosting an agent inside a
+// specific agent framework (its server, request-handler, and agent-card wiring) is
+// framework-specific glue and out of scope.
+package a2a
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+const (
+	defaultProtocolVersion = "0.3"
+	defaultInvokeTimeout   = 30 * time.Second
+	defaultJSONRPCPath     = "/a2a/jsonrpc"
+	jsonRPCMethodSend      = "message/send"
+	subjectTokenTypeAccess = "urn:ietf:params:oauth:token-type:access_token"
+)
+
+// DelegationClient delegates calls from one agent to another, carrying the user's
+// identity through an RFC 8693 token exchange. Construct it once per calling agent.
+type DelegationClient struct {
+	exchange        *oauth.TokenExchangeClient
+	discovery       *ServiceDiscovery
+	httpClient      *http.Client
+	protocolVersion string
+}
+
+// DelegationOption configures a DelegationClient.
+type DelegationOption func(*delegationConfig)
+
+type delegationConfig struct {
+	httpClient      *http.Client
+	discovery       *ServiceDiscovery
+	protocolVersion string
+}
+
+// WithHTTPClient sets the HTTP client used for both the token exchange and the agent
+// invocation. The default client has a 30 second timeout.
+func WithHTTPClient(c *http.Client) DelegationOption {
+	return func(cfg *delegationConfig) { cfg.httpClient = c }
+}
+
+// WithServiceDiscovery supplies a shared ServiceDiscovery (for a shared agent-card
+// cache). When unset, the client uses its own ServiceDiscovery with default settings.
+func WithServiceDiscovery(d *ServiceDiscovery) DelegationOption {
+	return func(cfg *delegationConfig) { cfg.discovery = d }
+}
+
+// WithProtocolVersion sets the A2A protocol version advertised on invocation requests
+// via the x-a2a-protocol-version header. Defaults to "0.3".
+func WithProtocolVersion(v string) DelegationOption {
+	return func(cfg *delegationConfig) { cfg.protocolVersion = v }
+}
+
+// NewDelegationClient builds a delegation client for one calling agent. issuer is the
+// Keycard zone authorization server where each token exchange is performed; clientID
+// and clientSecret are the calling agent's own credential, used to authenticate the
+// exchange and to identify the agent in the act chain. It returns a ConfigurationError
+// if the issuer, client ID, or client secret is empty.
+func NewDelegationClient(issuer, clientID, clientSecret string, opts ...DelegationOption) (*DelegationClient, error) {
+	if strings.TrimSpace(issuer) == "" {
+		return nil, &ConfigurationError{Message: "issuer must not be empty"}
+	}
+	if strings.TrimSpace(clientID) == "" || strings.TrimSpace(clientSecret) == "" {
+		return nil, &ConfigurationError{Message: "client_id and client_secret must not be empty"}
+	}
+
+	cfg := delegationConfig{protocolVersion: defaultProtocolVersion}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	httpClient := cfg.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultInvokeTimeout}
+	}
+
+	discovery := cfg.discovery
+	if discovery == nil {
+		discovery = NewServiceDiscovery()
+	}
+
+	exchange := oauth.NewTokenExchangeClient(issuer,
+		oauth.WithClientCredentials(clientID, clientSecret),
+		oauth.WithTokenExchangeHTTPClient(httpClient),
+	)
+
+	return &DelegationClient{
+		exchange:        exchange,
+		discovery:       discovery,
+		httpClient:      httpClient,
+		protocolVersion: cfg.protocolVersion,
+	}, nil
+}
+
+// Invoke delegates a call to the target agent on the user's behalf. It discovers the
+// target's card, exchanges subjectToken (the inbound user token) for a token scoped to
+// the target, and invokes the target's JSON-RPC endpoint with that token, sending msg.
+//
+// A discovery, exchange, or invocation failure is returned as a *DiscoveryError, an
+// OAuth error from the exchange (wrapped), or an *InvocationError respectively. On an
+// exchange failure the target agent is not invoked.
+func (c *DelegationClient) Invoke(ctx context.Context, target, subjectToken string, msg Message) (*Result, error) {
+	if strings.TrimSpace(subjectToken) == "" {
+		return nil, &ConfigurationError{Message: "subject_token must not be empty"}
+	}
+
+	card, err := c.discovery.GetCard(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	audience := strings.TrimRight(target, "/")
+	tokenResp, err := c.exchange.ExchangeToken(ctx, oauth.TokenExchangeRequest{
+		SubjectToken:     subjectToken,
+		SubjectTokenType: subjectTokenTypeAccess,
+		Resource:         audience,
+		Audience:         audience,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("a2a delegation: token exchange for %s: %w", audience, err)
+	}
+
+	respMsg, err := c.invoke(ctx, c.jsonRPCEndpoint(target, card), tokenResp.AccessToken, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{Message: respMsg, AgentCard: card}, nil
+}
+
+// jsonRPCEndpoint resolves the target's JSON-RPC endpoint: the card's url when set,
+// otherwise the target base URL with the conventional /a2a/jsonrpc path.
+func (c *DelegationClient) jsonRPCEndpoint(target string, card AgentCard) string {
+	if strings.TrimSpace(card.URL) != "" {
+		return card.URL
+	}
+	return strings.TrimRight(target, "/") + defaultJSONRPCPath
+}
+
+type jsonRPCRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      string        `json:"id"`
+	Method  string        `json:"method"`
+	Params  messageParams `json:"params"`
+}
+
+type messageParams struct {
+	Message Message `json:"message"`
+}
+
+type jsonRPCResponse struct {
+	Result *struct {
+		Message Message `json:"message"`
+	} `json:"result"`
+	Error *jsonRPCError `json:"error"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (c *DelegationClient) invoke(ctx context.Context, endpoint, bearer string, msg Message) (Message, error) {
+	body, err := json.Marshal(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      newUUID(),
+		Method:  jsonRPCMethodSend,
+		Params:  messageParams{Message: msg},
+	})
+	if err != nil {
+		return Message{}, &InvocationError{Message: "encoding request", Err: err}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return Message{}, &InvocationError{Message: "building request", Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	if c.protocolVersion != "" {
+		req.Header.Set("x-a2a-protocol-version", c.protocolVersion)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return Message{}, &InvocationError{Message: fmt.Sprintf("invoking %s", endpoint), Err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Message{}, &InvocationError{Message: fmt.Sprintf("agent %s returned HTTP %d", endpoint, resp.StatusCode)}
+	}
+
+	var rpcResp jsonRPCResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return Message{}, &InvocationError{Message: "decoding response", Err: err}
+	}
+	if rpcResp.Error != nil {
+		return Message{}, &InvocationError{Message: rpcResp.Error.Message, Code: rpcResp.Error.Code}
+	}
+	if rpcResp.Result == nil {
+		return Message{}, &InvocationError{Message: "agent response carried neither result nor error"}
+	}
+
+	return rpcResp.Result.Message, nil
+}

--- a/a2a/client_test.go
+++ b/a2a/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/keycardai/credentials-go/oauth"
 )
@@ -83,6 +84,8 @@ type fakeAgent struct {
 	lastBearer  string
 	failCode    int
 	failMessage string
+	hang        bool
+	emptyResult bool
 }
 
 func newFakeAgent(t *testing.T) *fakeAgent {
@@ -102,13 +105,32 @@ func newFakeAgent(t *testing.T) *fakeAgent {
 		a.lastBearer = r.Header.Get("Authorization")
 		failMessage := a.failMessage
 		failCode := a.failCode
+		hang := a.hang
+		emptyResult := a.emptyResult
 		a.mu.Unlock()
+
+		if hang {
+			// Return when the client cancels, but cap it so the test server's Close()
+			// never blocks waiting on this handler.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(time.Second):
+			}
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if failMessage != "" {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"error":   map[string]any{"code": failCode, "message": failMessage},
+			})
+			return
+		}
+		if emptyResult {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"result":  map[string]any{},
 			})
 			return
 		}
@@ -222,6 +244,111 @@ func TestDelegationClient_Invoke_JSONRPCError(t *testing.T) {
 	if invErr.Code != -32000 {
 		t.Errorf("invocation error code: got %d, want -32000", invErr.Code)
 	}
+}
+
+// Review #1: the per-call timeout bounds Invoke even when the caller supplies an
+// http.Client with no Timeout, and surfaces the deadline as an InvocationError.
+func TestDelegationClient_Invoke_TimesOutIndependentOfClient(t *testing.T) {
+	zone := newFakeZone(t)
+	agent := newFakeAgent(t)
+	agent.hang = true
+
+	client, err := NewDelegationClient(zone.URL, "agent-client", "agent-secret",
+		WithHTTPClient(&http.Client{}), // no Timeout of its own
+		WithInvokeTimeout(150*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+
+	start := time.Now()
+	_, err = client.Invoke(context.Background(), agent.URL, "user-token", NewTextMessage("hi"))
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Invoke ignored the invoke timeout (took %s)", elapsed)
+	}
+	var invErr *InvocationError
+	if !errors.As(err, &invErr) {
+		t.Errorf("errors.As(*InvocationError): got %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(context.DeadlineExceeded): got %v", err)
+	}
+}
+
+// Review #4: a result object present but carrying no message is an invocation error,
+// not a silent empty success.
+func TestDelegationClient_Invoke_EmptyResultMessage(t *testing.T) {
+	zone := newFakeZone(t)
+	agent := newFakeAgent(t)
+	agent.emptyResult = true
+
+	client, err := NewDelegationClient(zone.URL, "agent-client", "agent-secret")
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+
+	_, err = client.Invoke(context.Background(), agent.URL, "user-token", NewTextMessage("hi"))
+	var invErr *InvocationError
+	if !errors.As(err, &invErr) {
+		t.Fatalf("errors.As(*InvocationError): got %v", err)
+	}
+}
+
+// Review #2: a caller-supplied HTTP client governs agent-card discovery too.
+func TestDelegationClient_HTTPClientGovernsDiscovery(t *testing.T) {
+	zone := newFakeZone(t)
+	agent := newFakeAgent(t)
+
+	rt := &recordingTransport{base: http.DefaultTransport}
+	client, err := NewDelegationClient(zone.URL, "agent-client", "agent-secret",
+		WithHTTPClient(&http.Client{Transport: rt}),
+	)
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+
+	if _, err := client.Invoke(context.Background(), agent.URL, "user-token", NewTextMessage("hi")); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if !rt.sawPath(agentCardPath) {
+		t.Errorf("agent-card discovery did not use the supplied HTTP client; paths=%v", rt.seenPaths())
+	}
+}
+
+// recordingTransport records the request paths it forwards, for asserting which client
+// served a given request.
+type recordingTransport struct {
+	base  http.RoundTripper
+	mu    sync.Mutex
+	paths []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.paths = append(rt.paths, req.URL.Path)
+	rt.mu.Unlock()
+	return rt.base.RoundTrip(req)
+}
+
+func (rt *recordingTransport) sawPath(p string) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, x := range rt.paths {
+		if x == p {
+			return true
+		}
+	}
+	return false
+}
+
+func (rt *recordingTransport) seenPaths() []string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]string(nil), rt.paths...)
 }
 
 func TestNewDelegationClient_RejectsEmpty(t *testing.T) {

--- a/a2a/client_test.go
+++ b/a2a/client_test.go
@@ -1,0 +1,256 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+// fakeZone is a fake Keycard authorization server: it advertises a token endpoint and
+// performs (or rejects) the RFC 8693 exchange, recording the basic-auth client id it
+// received so a test can assert the calling agent's credential was used.
+type fakeZone struct {
+	*httptest.Server
+	mu           sync.Mutex
+	exchanges    int
+	lastClientID string
+	reject       bool
+}
+
+func newFakeZone(t *testing.T) *fakeZone {
+	t.Helper()
+	z := &fakeZone{}
+	mux := http.NewServeMux()
+	z.Server = httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":         z.URL,
+			"token_endpoint": z.URL + "/token",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		id, _, _ := r.BasicAuth()
+		z.mu.Lock()
+		z.exchanges++
+		z.lastClientID = id
+		reject := z.reject
+		z.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if reject {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"error":             "invalid_grant",
+				"error_description": "user token not accepted for target",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "exchanged-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	})
+	t.Cleanup(z.Close)
+	return z
+}
+
+func (z *fakeZone) exchangeCount() int {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.exchanges
+}
+
+func (z *fakeZone) clientID() string {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return z.lastClientID
+}
+
+// fakeAgent is a fake target agent: it serves its card and a JSON-RPC endpoint that
+// records the bearer token it was invoked with and returns either a response message
+// or a JSON-RPC error.
+type fakeAgent struct {
+	*httptest.Server
+	mu          sync.Mutex
+	invocations int
+	lastBearer  string
+	failCode    int
+	failMessage string
+}
+
+func newFakeAgent(t *testing.T) *fakeAgent {
+	t.Helper()
+	a := &fakeAgent{}
+	mux := http.NewServeMux()
+	a.Server = httptest.NewServer(mux)
+	mux.HandleFunc(agentCardPath, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "Target Agent",
+			"url":  a.URL + "/a2a/jsonrpc",
+		})
+	})
+	mux.HandleFunc("/a2a/jsonrpc", func(w http.ResponseWriter, r *http.Request) {
+		a.mu.Lock()
+		a.invocations++
+		a.lastBearer = r.Header.Get("Authorization")
+		failMessage := a.failMessage
+		failCode := a.failCode
+		a.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if failMessage != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"error":   map[string]any{"code": failCode, "message": failMessage},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"result": map[string]any{
+				"message": map[string]any{
+					"messageId": "resp-1",
+					"role":      RoleAgent,
+					"parts":     []map[string]any{{"kind": "text", "text": "handled"}},
+				},
+			},
+		})
+	})
+	t.Cleanup(a.Close)
+	return a
+}
+
+func (a *fakeAgent) invocationCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.invocations
+}
+
+func (a *fakeAgent) bearer() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.lastBearer
+}
+
+// Spec test 3: a valid user token is exchanged for a target-scoped token and the agent
+// is invoked with it.
+func TestDelegationClient_Invoke_ExchangesThenInvokes(t *testing.T) {
+	zone := newFakeZone(t)
+	agent := newFakeAgent(t)
+
+	client, err := NewDelegationClient(zone.URL, "agent-client", "agent-secret")
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+
+	res, err := client.Invoke(context.Background(), agent.URL, "user-token", NewTextMessage("do the thing"))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if zone.exchangeCount() != 1 {
+		t.Errorf("exchanges: got %d, want 1", zone.exchangeCount())
+	}
+	if zone.clientID() != "agent-client" {
+		t.Errorf("exchange authenticated as %q, want agent-client", zone.clientID())
+	}
+	if agent.invocationCount() != 1 {
+		t.Errorf("agent invocations: got %d, want 1", agent.invocationCount())
+	}
+	if got := agent.bearer(); got != "Bearer exchanged-token" {
+		t.Errorf("agent bearer: got %q, want the exchanged token", got)
+	}
+	if len(res.Message.Parts) != 1 || res.Message.Parts[0].Text != "handled" {
+		t.Errorf("response message: got %+v", res.Message)
+	}
+	if res.AgentCard.Name != "Target Agent" {
+		t.Errorf("resolved card name: got %q", res.AgentCard.Name)
+	}
+}
+
+// Spec test 4: the exchange is rejected by the zone; the token-exchange OAuth error
+// surfaces and the agent is not invoked.
+func TestDelegationClient_Invoke_ExchangeRejected(t *testing.T) {
+	zone := newFakeZone(t)
+	zone.reject = true
+	agent := newFakeAgent(t)
+
+	client, err := NewDelegationClient(zone.URL, "agent-client", "agent-secret")
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+
+	_, err = client.Invoke(context.Background(), agent.URL, "user-token", NewTextMessage("do the thing"))
+
+	var oauthErr *oauth.OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("error: got %v, want oauth.OAuthError", err)
+	}
+	if oauthErr.ErrorCode != "invalid_grant" {
+		t.Errorf("oauth error code: got %q, want invalid_grant", oauthErr.ErrorCode)
+	}
+	if agent.invocationCount() != 0 {
+		t.Errorf("agent invocations: got %d, want 0 (must not invoke on exchange failure)", agent.invocationCount())
+	}
+}
+
+// Spec test 5: the target returns a JSON-RPC error; an invocation error surfaces.
+func TestDelegationClient_Invoke_JSONRPCError(t *testing.T) {
+	zone := newFakeZone(t)
+	agent := newFakeAgent(t)
+	agent.failCode = -32000
+	agent.failMessage = "task failed"
+
+	client, err := NewDelegationClient(zone.URL, "agent-client", "agent-secret")
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+
+	_, err = client.Invoke(context.Background(), agent.URL, "user-token", NewTextMessage("do the thing"))
+
+	var invErr *InvocationError
+	if !errors.As(err, &invErr) {
+		t.Fatalf("error: got %v, want InvocationError", err)
+	}
+	if invErr.Code != -32000 {
+		t.Errorf("invocation error code: got %d, want -32000", invErr.Code)
+	}
+}
+
+func TestNewDelegationClient_RejectsEmpty(t *testing.T) {
+	cases := []struct {
+		name, issuer, clientID, clientSecret string
+	}{
+		{name: "empty issuer", issuer: "", clientID: "id", clientSecret: "secret"},
+		{name: "empty client_id", issuer: "https://zone.example.com", clientID: "", clientSecret: "secret"},
+		{name: "empty client_secret", issuer: "https://zone.example.com", clientID: "id", clientSecret: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewDelegationClient(tc.issuer, tc.clientID, tc.clientSecret)
+			var cfgErr *ConfigurationError
+			if !errors.As(err, &cfgErr) {
+				t.Fatalf("error: got %v, want ConfigurationError", err)
+			}
+		})
+	}
+}
+
+func TestDelegationClient_Invoke_RejectsEmptySubjectToken(t *testing.T) {
+	client, err := NewDelegationClient("https://zone.example.com", "id", "secret")
+	if err != nil {
+		t.Fatalf("NewDelegationClient: %v", err)
+	}
+	_, err = client.Invoke(context.Background(), "https://agent.example.com", "", NewTextMessage("hi"))
+	var cfgErr *ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want ConfigurationError", err)
+	}
+}

--- a/a2a/discovery.go
+++ b/a2a/discovery.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -25,6 +27,7 @@ type ServiceDiscovery struct {
 
 	mu    sync.Mutex
 	cache map[string]cardEntry
+	group singleflight.Group
 }
 
 type cardEntry struct {
@@ -61,24 +64,45 @@ func NewServiceDiscovery(opts ...DiscoveryOption) *ServiceDiscovery {
 }
 
 // GetCard returns the target agent's card, serving a cached copy while it is fresh and
-// fetching otherwise. It validates that the card carries a name.
+// fetching otherwise. Concurrent misses for the same target share a single fetch. It
+// validates that the card carries a name.
 func (d *ServiceDiscovery) GetCard(ctx context.Context, baseURL string) (AgentCard, error) {
 	key := strings.TrimRight(baseURL, "/")
 
-	d.mu.Lock()
-	if entry, ok := d.cache[key]; ok && time.Now().Before(entry.expiresAt) {
-		card := entry.card
-		d.mu.Unlock()
+	if card, ok := d.cachedFresh(key); ok {
 		return card, nil
 	}
-	d.mu.Unlock()
 
-	return d.Refresh(ctx, baseURL)
+	v, err, _ := d.group.Do(key, func() (any, error) {
+		// Another flight may have populated the cache while this one waited.
+		if card, ok := d.cachedFresh(key); ok {
+			return card, nil
+		}
+		return d.fetchAndCache(ctx, baseURL)
+	})
+	if err != nil {
+		return AgentCard{}, err
+	}
+	return v.(AgentCard), nil
 }
 
 // Refresh fetches the target agent's card, bypassing the cache, validates it, and
 // stores it in the cache.
 func (d *ServiceDiscovery) Refresh(ctx context.Context, baseURL string) (AgentCard, error) {
+	return d.fetchAndCache(ctx, baseURL)
+}
+
+// cachedFresh returns a cached card for key if present and not yet expired.
+func (d *ServiceDiscovery) cachedFresh(key string) (AgentCard, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if entry, ok := d.cache[key]; ok && time.Now().Before(entry.expiresAt) {
+		return entry.card, true
+	}
+	return AgentCard{}, false
+}
+
+func (d *ServiceDiscovery) fetchAndCache(ctx context.Context, baseURL string) (AgentCard, error) {
 	key := strings.TrimRight(baseURL, "/")
 	cardURL := key + agentCardPath
 

--- a/a2a/discovery.go
+++ b/a2a/discovery.go
@@ -1,0 +1,121 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	agentCardPath           = "/.well-known/agent-card.json"
+	defaultCacheTTL         = 15 * time.Minute
+	defaultDiscoveryTimeout = 10 * time.Second
+)
+
+// ServiceDiscovery resolves an agent's base URL to its agent card and caches the
+// result. Cards are cached for a configurable TTL (default 15 minutes) and can be
+// refreshed on demand. A ServiceDiscovery is safe for concurrent use.
+type ServiceDiscovery struct {
+	httpClient *http.Client
+	ttl        time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cardEntry
+}
+
+type cardEntry struct {
+	card      AgentCard
+	expiresAt time.Time
+}
+
+// DiscoveryOption configures a ServiceDiscovery.
+type DiscoveryOption func(*ServiceDiscovery)
+
+// WithDiscoveryHTTPClient sets the HTTP client used to fetch agent cards.
+func WithDiscoveryHTTPClient(c *http.Client) DiscoveryOption {
+	return func(d *ServiceDiscovery) { d.httpClient = c }
+}
+
+// WithCacheTTL sets how long a fetched agent card is served from cache.
+func WithCacheTTL(ttl time.Duration) DiscoveryOption {
+	return func(d *ServiceDiscovery) { d.ttl = ttl }
+}
+
+// NewServiceDiscovery creates a ServiceDiscovery with a default HTTP client and cache TTL.
+func NewServiceDiscovery(opts ...DiscoveryOption) *ServiceDiscovery {
+	d := &ServiceDiscovery{
+		ttl:   defaultCacheTTL,
+		cache: make(map[string]cardEntry),
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.httpClient == nil {
+		d.httpClient = &http.Client{Timeout: defaultDiscoveryTimeout}
+	}
+	return d
+}
+
+// GetCard returns the target agent's card, serving a cached copy while it is fresh and
+// fetching otherwise. It validates that the card carries a name.
+func (d *ServiceDiscovery) GetCard(ctx context.Context, baseURL string) (AgentCard, error) {
+	key := strings.TrimRight(baseURL, "/")
+
+	d.mu.Lock()
+	if entry, ok := d.cache[key]; ok && time.Now().Before(entry.expiresAt) {
+		card := entry.card
+		d.mu.Unlock()
+		return card, nil
+	}
+	d.mu.Unlock()
+
+	return d.Refresh(ctx, baseURL)
+}
+
+// Refresh fetches the target agent's card, bypassing the cache, validates it, and
+// stores it in the cache.
+func (d *ServiceDiscovery) Refresh(ctx context.Context, baseURL string) (AgentCard, error) {
+	key := strings.TrimRight(baseURL, "/")
+	cardURL := key + agentCardPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cardURL, nil)
+	if err != nil {
+		return AgentCard{}, &DiscoveryError{Message: "building agent card request", Err: err}
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return AgentCard{}, &DiscoveryError{Message: fmt.Sprintf("fetching %s", cardURL), Err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return AgentCard{}, &DiscoveryError{Message: fmt.Sprintf("agent card %s returned HTTP %d", cardURL, resp.StatusCode)}
+	}
+
+	var card AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		return AgentCard{}, &DiscoveryError{Message: fmt.Sprintf("decoding agent card %s", cardURL), Err: err}
+	}
+	if strings.TrimSpace(card.Name) == "" {
+		return AgentCard{}, &DiscoveryError{Message: fmt.Sprintf("agent card %s is missing the required name field", cardURL)}
+	}
+
+	d.mu.Lock()
+	d.cache[key] = cardEntry{card: card, expiresAt: time.Now().Add(d.ttl)}
+	d.mu.Unlock()
+
+	return card, nil
+}
+
+// ClearCache discards all cached agent cards.
+func (d *ServiceDiscovery) ClearCache() {
+	d.mu.Lock()
+	d.cache = make(map[string]cardEntry)
+	d.mu.Unlock()
+}

--- a/a2a/discovery_test.go
+++ b/a2a/discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -92,6 +93,45 @@ func TestServiceDiscovery_Refresh_BypassesCache(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(hits); got != 2 {
 		t.Errorf("card fetches: got %d, want 2 (Refresh should bypass cache)", got)
+	}
+}
+
+// Review #3: concurrent first-time lookups for the same target share one fetch.
+func TestServiceDiscovery_GetCard_SingleFlight(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != agentCardPath {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&hits, 1)
+		time.Sleep(100 * time.Millisecond) // hold the flight open so concurrent callers join it
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"name": "Target Agent"})
+	}))
+	defer server.Close()
+
+	d := NewServiceDiscovery()
+	const n = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := d.GetCard(context.Background(), server.URL); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("GetCard: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("card fetches: got %d, want 1 (concurrent misses should share one fetch)", got)
 	}
 }
 

--- a/a2a/discovery_test.go
+++ b/a2a/discovery_test.go
@@ -1,0 +1,112 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cardServer is a fake agent that serves its card at the well-known path and counts
+// how many times the card was fetched.
+func cardServer(t *testing.T, card map[string]any, status int) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != agentCardPath {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&hits, 1)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(card)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// Spec test 1: discover a healthy agent; the card is returned and a second lookup is
+// served from cache.
+func TestServiceDiscovery_GetCard_CachesHealthyCard(t *testing.T) {
+	srv, hits := cardServer(t, map[string]any{"name": "Target Agent"}, http.StatusOK)
+
+	d := NewServiceDiscovery()
+	card, err := d.GetCard(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("GetCard: %v", err)
+	}
+	if card.Name != "Target Agent" {
+		t.Errorf("name: got %q, want Target Agent", card.Name)
+	}
+
+	if _, err := d.GetCard(context.Background(), srv.URL); err != nil {
+		t.Fatalf("second GetCard: %v", err)
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Errorf("card fetches: got %d, want 1 (second lookup should be cached)", got)
+	}
+}
+
+// Spec test 2: discover a card missing name; a discovery error surfaces.
+func TestServiceDiscovery_GetCard_MissingName(t *testing.T) {
+	srv, _ := cardServer(t, map[string]any{"url": "https://agent.example.com/a2a/jsonrpc"}, http.StatusOK)
+
+	d := NewServiceDiscovery()
+	_, err := d.GetCard(context.Background(), srv.URL)
+
+	var discErr *DiscoveryError
+	if !errors.As(err, &discErr) {
+		t.Fatalf("error: got %v, want DiscoveryError", err)
+	}
+}
+
+func TestServiceDiscovery_GetCard_HTTPError(t *testing.T) {
+	srv, _ := cardServer(t, nil, http.StatusInternalServerError)
+
+	d := NewServiceDiscovery()
+	_, err := d.GetCard(context.Background(), srv.URL)
+
+	var discErr *DiscoveryError
+	if !errors.As(err, &discErr) {
+		t.Fatalf("error: got %v, want DiscoveryError", err)
+	}
+}
+
+func TestServiceDiscovery_Refresh_BypassesCache(t *testing.T) {
+	srv, hits := cardServer(t, map[string]any{"name": "Target Agent"}, http.StatusOK)
+
+	d := NewServiceDiscovery()
+	if _, err := d.GetCard(context.Background(), srv.URL); err != nil {
+		t.Fatalf("GetCard: %v", err)
+	}
+	if _, err := d.Refresh(context.Background(), srv.URL); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := atomic.LoadInt32(hits); got != 2 {
+		t.Errorf("card fetches: got %d, want 2 (Refresh should bypass cache)", got)
+	}
+}
+
+func TestServiceDiscovery_GetCard_RefetchesAfterTTL(t *testing.T) {
+	srv, hits := cardServer(t, map[string]any{"name": "Target Agent"}, http.StatusOK)
+
+	d := NewServiceDiscovery(WithCacheTTL(5 * time.Millisecond))
+	if _, err := d.GetCard(context.Background(), srv.URL); err != nil {
+		t.Fatalf("GetCard: %v", err)
+	}
+	time.Sleep(25 * time.Millisecond)
+	if _, err := d.GetCard(context.Background(), srv.URL); err != nil {
+		t.Fatalf("second GetCard: %v", err)
+	}
+	if got := atomic.LoadInt32(hits); got != 2 {
+		t.Errorf("card fetches: got %d, want 2 (cache should expire after TTL)", got)
+	}
+}

--- a/a2a/errors.go
+++ b/a2a/errors.go
@@ -1,0 +1,52 @@
+package a2a
+
+import "fmt"
+
+// ConfigurationError indicates a delegation client or invocation was given invalid
+// configuration, such as an empty issuer, credential, or subject token.
+type ConfigurationError struct {
+	Message string
+}
+
+func (e *ConfigurationError) Error() string {
+	return "a2a: " + e.Message
+}
+
+// DiscoveryError indicates a target agent's card could not be resolved: the card
+// could not be fetched, was not valid JSON, or was missing the required name field.
+type DiscoveryError struct {
+	Message string
+	Err     error
+}
+
+func (e *DiscoveryError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("a2a discovery: %s: %v", e.Message, e.Err)
+	}
+	return "a2a discovery: " + e.Message
+}
+
+func (e *DiscoveryError) Unwrap() error {
+	return e.Err
+}
+
+// InvocationError indicates a JSON-RPC invocation of a target agent failed: the
+// transport returned an HTTP error, the response could not be decoded, or the agent
+// returned a JSON-RPC error response. Code carries the JSON-RPC error code when the
+// failure came from a JSON-RPC error response.
+type InvocationError struct {
+	Message string
+	Code    int
+	Err     error
+}
+
+func (e *InvocationError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("a2a invocation: %s: %v", e.Message, e.Err)
+	}
+	return "a2a invocation: " + e.Message
+}
+
+func (e *InvocationError) Unwrap() error {
+	return e.Err
+}

--- a/a2a/example_test.go
+++ b/a2a/example_test.go
@@ -1,0 +1,61 @@
+package a2a_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/keycardai/credentials-go/a2a"
+)
+
+// ExampleDelegationClient_Invoke shows a calling agent delegating a task to a target
+// agent on the user's behalf. The fake servers stand in for a Keycard zone and the
+// target agent.
+func ExampleDelegationClient_Invoke() {
+	// A Keycard zone that performs the RFC 8693 token exchange.
+	zone := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":         "http://" + r.Host,
+				"token_endpoint": "http://" + r.Host + "/token",
+			})
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "scoped-token", "token_type": "bearer"})
+		}
+	}))
+	defer zone.Close()
+
+	// The target agent: serves its card and a JSON-RPC endpoint.
+	var agent *httptest.Server
+	agent = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/agent-card.json":
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "Weather Agent", "url": agent.URL + "/a2a/jsonrpc"})
+		case "/a2a/jsonrpc":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"result": map[string]any{"message": map[string]any{
+					"messageId": "m1",
+					"role":      "agent",
+					"parts":     []map[string]any{{"kind": "text", "text": "Sunny, 72F"}},
+				}},
+			})
+		}
+	}))
+	defer agent.Close()
+
+	client, err := a2a.NewDelegationClient(zone.URL, "calling-agent", "agent-secret")
+	if err != nil {
+		panic(err)
+	}
+
+	result, err := client.Invoke(context.Background(), agent.URL, "inbound-user-token", a2a.NewTextMessage("what's the weather?"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s says: %s\n", result.AgentCard.Name, result.Message.Parts[0].Text)
+	// Output: Weather Agent says: Sunny, 72F
+}

--- a/a2a/message.go
+++ b/a2a/message.go
@@ -1,0 +1,65 @@
+package a2a
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// Message roles, per the A2A protocol.
+const (
+	RoleUser  = "user"
+	RoleAgent = "agent"
+)
+
+// Part is one piece of a Message. A text part carries Kind "text" and a Text body.
+type Part struct {
+	Kind string `json:"kind"`
+	Text string `json:"text,omitempty"`
+}
+
+// Message is an A2A message exchanged with an agent: a role, an ordered list of
+// content parts, and optional metadata.
+type Message struct {
+	MessageID string         `json:"messageId"`
+	Role      string         `json:"role"`
+	Parts     []Part         `json:"parts"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// AgentCard is the subset of an A2A agent card this package reads. The card carries
+// many more fields; only name (required) and url (used to resolve the JSON-RPC
+// endpoint) are consumed here.
+type AgentCard struct {
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	URL             string `json:"url,omitempty"`
+	Version         string `json:"version,omitempty"`
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
+}
+
+// Result is the outcome of a delegated invocation: the agent's response message and
+// the agent card that was resolved for the call.
+type Result struct {
+	Message   Message
+	AgentCard AgentCard
+}
+
+// NewTextMessage builds a user-role message carrying a single text part, with a
+// freshly generated message ID.
+func NewTextMessage(text string) Message {
+	return Message{
+		MessageID: newUUID(),
+		Role:      RoleUser,
+		Parts:     []Part{{Kind: "text", Text: text}},
+	}
+}
+
+// newUUID returns a random RFC 4122 version 4 UUID string. crypto/rand.Read does not
+// fail on any supported platform, so its error is not surfaced.
+func newUUID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/examples/a2a/main.go
+++ b/examples/a2a/main.go
@@ -1,0 +1,64 @@
+// Package main demonstrates agent-to-agent (A2A) delegation: a calling agent delegates
+// a task to a target agent on the user's behalf. The delegation client discovers the
+// target's agent card, exchanges the inbound user token for one scoped to the target
+// (RFC 8693, authenticated with the calling agent's own credential), and invokes the
+// target's A2A JSON-RPC endpoint with the exchanged token.
+//
+// Configure before running:
+//   - KEYCARD_ZONE_URL, e.g. https://your-zone.keycard.cloud (the authorization server)
+//   - KEYCARD_A2A_CLIENT_ID / KEYCARD_A2A_CLIENT_SECRET (the calling agent's credential)
+//   - A2A_TARGET_URL, the target agent's base URL, e.g. https://other-agent.example.com
+//   - A2A_SUBJECT_TOKEN, the inbound user's verified access token
+//   - A2A_MESSAGE, optional text to send (defaults to a greeting)
+//
+// Run:
+//
+//	KEYCARD_ZONE_URL=... KEYCARD_A2A_CLIENT_ID=... KEYCARD_A2A_CLIENT_SECRET=... \
+//	A2A_TARGET_URL=... A2A_SUBJECT_TOKEN=... go run ./examples/a2a
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/keycardai/credentials-go/a2a"
+)
+
+func main() {
+	zoneURL := os.Getenv("KEYCARD_ZONE_URL")
+	clientID := os.Getenv("KEYCARD_A2A_CLIENT_ID")
+	clientSecret := os.Getenv("KEYCARD_A2A_CLIENT_SECRET")
+	targetURL := os.Getenv("A2A_TARGET_URL")
+	subjectToken := os.Getenv("A2A_SUBJECT_TOKEN")
+	if zoneURL == "" || clientID == "" || clientSecret == "" || targetURL == "" || subjectToken == "" {
+		log.Fatal("set KEYCARD_ZONE_URL, KEYCARD_A2A_CLIENT_ID, KEYCARD_A2A_CLIENT_SECRET, A2A_TARGET_URL, and A2A_SUBJECT_TOKEN")
+	}
+
+	text := os.Getenv("A2A_MESSAGE")
+	if text == "" {
+		text = "Hello from the calling agent."
+	}
+
+	client, err := a2a.NewDelegationClient(zoneURL, clientID, clientSecret)
+	if err != nil {
+		log.Fatalf("building delegation client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := client.Invoke(ctx, targetURL, subjectToken, a2a.NewTextMessage(text))
+	if err != nil {
+		log.Fatalf("delegating to %s: %v", targetURL, err)
+	}
+
+	fmt.Printf("Delegated to %q (%s)\n", result.AgentCard.Name, targetURL)
+	for _, part := range result.Message.Parts {
+		if part.Text != "" {
+			fmt.Printf("Response: %s\n", part.Text)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds the `a2a` package: Go's implementation of Keycard's agent-to-agent delegation contract, where one agent service calls another on the user's behalf. Brings Go to parity with the Python (`keycardai-a2a`) and TypeScript (`@keycardai/a2a`) delegation surface.

- **`ServiceDiscovery`** resolves a target agent's base URL to its card at `/.well-known/agent-card.json`, validates the card carries a `name`, and caches it (default 15-minute TTL, `Refresh` to bypass).
- **`DelegationClient.Invoke`** runs the three-step contract: discover the card, perform an RFC 8693 token exchange (subject = the inbound user token, `resource`/`audience` = the target, authenticated with the calling agent's own client-secret credential), then invoke the target's A2A JSON-RPC endpoint (`message/send`) with the exchanged token as the bearer credential.
- Failures surface as distinct types: `*DiscoveryError`, the wrapped `oauth.OAuthError` from the exchange, and `*InvocationError` (carrying the JSON-RPC code). On an exchange failure the target is not invoked.

## Why

A2A delegation existed in Python and TypeScript but not Go ([spec](../keycard-sdk-spec/specs/a2a/a2a-delegation.md) explicitly tracks "Go: no A2A integration exists"). This is the Go side of that effort. The package depends only on `oauth` (it builds on the existing `oauth.TokenExchangeClient`) and does not touch `mcp`.

## Design notes (spec divergences)

The spec's "Divergences & parity" section flags two minor, cross-SDK-unsettled conventions; Go picks the TypeScript-aligned option for both:
- **JSON-RPC endpoint resolution**: prefer the card's `url`, falling back to `<target>/a2a/jsonrpc` by convention (TS derives from the card; Python hardcodes the path).
- **Protocol-version header**: sends `x-a2a-protocol-version: 0.3` (configurable via `WithProtocolVersion`), matching TS.
- **No explicit `actor_token`**: like both SDKs, the calling agent authenticates the exchange with its credential and lets the authorization server mint the `act` chain.

Scope matches the spec: the delegation client only. Hosting an agent inside a specific agent framework (server/request-handler/agent-card wiring) is framework glue and out of scope.

## Verify

- `go build ./... ./examples/...`, `go vet ./...`, `gofmt -l` clean
- `go test -race -count=1 ./a2a/` covers the spec's five Testing cases (discover + cache, missing-`name` discovery error, exchange-then-invoke, exchange-rejected surfaces the OAuth error without invoking, JSON-RPC error surfaces) plus construction validation
- A runnable example (`examples/a2a`) and a `go test`-verified godoc example (`ExampleDelegationClient_Invoke`)

Linear: ECO-95.