### PR TITLE
feat(mcp): serve public JWKS at /.well-known/jwks.json (ECO-94)

### DIFF
--- a/mcp/metadata.go
+++ b/mcp/metadata.go
@@ -12,6 +12,7 @@ import (
 type ProtectedResourceMetadata struct {
 	Resource              string   `json:"resource"`
 	AuthorizationServers  []string `json:"authorization_servers,omitempty"`
+	JWKSURI               string   `json:"jwks_uri,omitempty"`
 	ScopesSupported       []string `json:"scopes_supported,omitempty"`
 	ResourceName          string   `json:"resource_name,omitempty"`
 	ResourceDocumentation string   `json:"resource_documentation,omitempty"`
@@ -103,6 +104,11 @@ func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 		}
 		if cfg.issuer != "" {
 			metadata.AuthorizationServers = []string{cfg.issuer}
+		}
+		// When this server publishes its JWKS, advertise its location (RFC 9728 jwks_uri)
+		// so the one WithPublicJWKS option both serves and advertises, as Python couples them.
+		if cfg.publicJWKS != nil {
+			metadata.JWKSURI = baseURL + "/.well-known/jwks.json"
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/mcp/metadata.go
+++ b/mcp/metadata.go
@@ -26,6 +26,7 @@ type metadataConfig struct {
 	resourceName          string
 	resourceDocumentation string
 	httpClient            *http.Client
+	publicJWKS            map[string]any
 }
 
 // WithIssuer sets the authorization server issuer URL.
@@ -51,6 +52,13 @@ func WithServiceDocumentationURL(docURL string) MetadataOption {
 // WithMetadataHTTPClient sets the HTTP client used to fetch upstream authorization server metadata.
 func WithMetadataHTTPClient(c *http.Client) MetadataOption {
 	return func(cfg *metadataConfig) { cfg.httpClient = c }
+}
+
+// WithPublicJWKS serves the given JWKS document (e.g. from WebIdentityCredential.PublicJWKS())
+// at /.well-known/jwks.json, so an authorization server can fetch this resource's public keys
+// to verify its private_key_jwt client assertions. When unset, the route is not registered.
+func WithPublicJWKS(jwks map[string]any) MetadataOption {
+	return func(cfg *metadataConfig) { cfg.publicJWKS = jwks }
 }
 
 // AuthMetadataHandler returns an http.Handler that serves both
@@ -153,6 +161,14 @@ func AuthMetadataHandler(opts ...MetadataOption) http.Handler {
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(metadata)
+		})
+	}
+
+	if cfg.publicJWKS != nil {
+		mux.HandleFunc("GET /.well-known/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
+			setCORSHeaders(w)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cfg.publicJWKS)
 		})
 	}
 

--- a/mcp/metadata_test.go
+++ b/mcp/metadata_test.go
@@ -227,3 +227,48 @@ func TestAuthMetadataHandler_CORSHeaders(t *testing.T) {
 		t.Error("missing CORS origin header")
 	}
 }
+
+func TestAuthMetadataHandler_PublicJWKS(t *testing.T) {
+	jwks := map[string]any{
+		"keys": []any{
+			map[string]any{"kty": "RSA", "kid": "server-key-1", "use": "sig", "n": "abc", "e": "AQAB"},
+		},
+	}
+	handler := AuthMetadataHandler(WithPublicJWKS(jwks))
+
+	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("missing CORS origin header")
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	keys, ok := body["keys"].([]any)
+	if !ok || len(keys) != 1 {
+		t.Fatalf("keys: got %v", body["keys"])
+	}
+	if kid := keys[0].(map[string]any)["kid"]; kid != "server-key-1" {
+		t.Errorf("kid: got %v", kid)
+	}
+}
+
+func TestAuthMetadataHandler_PublicJWKSOmittedByDefault(t *testing.T) {
+	handler := AuthMetadataHandler(WithIssuer("https://auth.example.com"))
+
+	req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Without WithPublicJWKS the route is not registered, so no JWKS document is served.
+	if rec.Code == http.StatusOK {
+		t.Errorf("status: got 200, want non-200 (jwks route should not be registered without WithPublicJWKS)")
+	}
+}

--- a/mcp/metadata_test.go
+++ b/mcp/metadata_test.go
@@ -260,6 +260,38 @@ func TestAuthMetadataHandler_PublicJWKS(t *testing.T) {
 	}
 }
 
+func TestAuthMetadataHandler_AdvertisesJWKSURI(t *testing.T) {
+	jwks := map[string]any{"keys": []any{}}
+	handler := AuthMetadataHandler(WithIssuer("https://zone.example.com"), WithPublicJWKS(jwks))
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+	req.Host = "mcp.example.com"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var metadata ProtectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&metadata); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if metadata.JWKSURI != "http://mcp.example.com/.well-known/jwks.json" {
+		t.Errorf("jwks_uri: got %q, want the served JWKS location", metadata.JWKSURI)
+	}
+}
+
+func TestAuthMetadataHandler_JWKSURIOmittedWithoutPublicJWKS(t *testing.T) {
+	handler := AuthMetadataHandler(WithIssuer("https://zone.example.com"))
+
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var metadata ProtectedResourceMetadata
+	json.NewDecoder(rec.Body).Decode(&metadata)
+	if metadata.JWKSURI != "" {
+		t.Errorf("jwks_uri: got %q, want empty when no JWKS is published", metadata.JWKSURI)
+	}
+}
+
 func TestAuthMetadataHandler_PublicJWKSOmittedByDefault(t *testing.T) {
 	handler := AuthMetadataHandler(WithIssuer("https://auth.example.com"))
 


### PR DESCRIPTION
## What

Adds a `WithPublicJWKS` option to `AuthMetadataHandler` that serves a JWKS document at `/.well-known/jwks.json` (with CORS + `application/json`). The route is registered only when the option is set.

```go
mcp.AuthMetadataHandler(
    mcp.WithIssuer(zoneURL),
    mcp.WithPublicJWKS(cred.PublicJWKS()), // cred is a *WebIdentityCredential
)
```

## Why

This is the remaining `oauth-metadata-endpoints` item of ECO-94. A `WebIdentityCredential` signs `private_key_jwt` client assertions; the authorization server needs to fetch the resource's public keys to verify them. `WebIdentityCredential.PublicJWKS()` already produces the JWKS document, but there was no built-in way to publish it at the well-known path — callers had to hand-roll the route. This closes that gap and matches the Python/TS surface.

## Verify

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./mcp/...`:
  - `TestAuthMetadataHandler_PublicJWKS`: the route returns the JWKS with CORS headers and the expected `keys`.
  - `TestAuthMetadataHandler_PublicJWKSOmittedByDefault`: without the option, no JWKS is served.

Linear: ECO-94 (ticks the final `oauth-metadata-endpoints` box). With this + B4 (AccessContext move + grant-decorator), ECO-94 is complete.