### PR TITLE
feat(mcp)!: move AccessContext to oauth and add the Grant decorator (ECO-94)

### DIFF
--- a/examples/delegated-access/main.go
+++ b/examples/delegated-access/main.go
@@ -56,7 +56,7 @@ func main() {
 	apiHandler := mcp.RequireBearerAuth(
 		verifier,
 		mcp.WithRequiredScopes("mcp:tools"),
-	)(authProvider.Grant("https://api.github.com")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	)(authProvider.Grant([]string{"https://api.github.com"})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ac := mcp.AccessContextFromRequest(r)
 
 		if ac.HasErrors() {

--- a/examples/multi-zone/main.go
+++ b/examples/multi-zone/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// Grant routes the exchange to whichever zone minted the request's token.
 	handler := mcp.RequireBearerAuth(verifier)(
-		provider.Grant(resource)(
+		provider.Grant([]string{resource})(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				info := mcp.AuthInfoFromRequest(r)
 				ac := mcp.AccessContextFromRequest(r)

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -1,16 +1,10 @@
 package mcp
 
-// ResourceAccessError is returned when a resource's token is unavailable.
-type ResourceAccessError struct {
-	Message string
-}
+import "github.com/keycardai/credentials-go/oauth"
 
-func (e *ResourceAccessError) Error() string {
-	if e.Message != "" {
-		return e.Message
-	}
-	return "resource access error"
-}
+// ResourceAccessError is re-exported from the oauth package (where it now lives alongside
+// AccessContext) for backward compatibility.
+type ResourceAccessError = oauth.ResourceAccessError
 
 // AuthProviderConfigurationError indicates invalid AuthProvider configuration.
 type AuthProviderConfigurationError struct {

--- a/mcp/grant_test.go
+++ b/mcp/grant_test.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+// grantTokenServer is a fake zone that serves discovery and a /token endpoint, recording
+// the form of every token request so a test can assert how the grant exchanged.
+type grantTokenServer struct {
+	*httptest.Server
+	mu    sync.Mutex
+	forms []url.Values
+}
+
+func newGrantTokenServer(t *testing.T) *grantTokenServer {
+	t.Helper()
+	s := &grantTokenServer{}
+	mux := http.NewServeMux()
+	s.Server = httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"issuer": s.URL, "token_endpoint": s.URL + "/token"})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		s.mu.Lock()
+		s.forms = append(s.forms, r.Form)
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok-for-" + r.Form.Get("resource"), "token_type": "bearer"})
+	})
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *grantTokenServer) tokenForms() []url.Values {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]url.Values, len(s.forms))
+	copy(out, s.forms)
+	return out
+}
+
+// runGrant drives the grant middleware with an injected AuthInfo and returns the
+// resulting AccessContext.
+func runGrant(t *testing.T, issuer, token string, mw func(http.Handler) http.Handler) *AccessContext {
+	t.Helper()
+	var captured *AccessContext
+	handler := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = AccessContextFromRequest(r)
+	}))
+	req := httptest.NewRequest("POST", "/mcp", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authInfoKey, &AuthInfo{Token: token, Issuer: issuer}))
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	return captured
+}
+
+func newSingleZoneProvider(t *testing.T, zoneURL string) *AuthProvider {
+	t.Helper()
+	provider, err := NewAuthProvider(
+		WithZoneURL(zoneURL),
+		WithApplicationCredential(mustClientSecret(t, "agent-client", "agent-secret")),
+	)
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+	return provider
+}
+
+func TestGrant_RequestScopes(t *testing.T) {
+	zone := newGrantTokenServer(t)
+	provider := newSingleZoneProvider(t, zone.URL)
+
+	ac := runGrant(t, zone.URL, "user-token",
+		provider.Grant([]string{"https://api.example.com"}, WithRequestScopes("read", "write")))
+
+	if ac.Status() != StatusSuccess {
+		t.Fatalf("status: got %q, want success", ac.Status())
+	}
+
+	var exchange url.Values
+	for _, f := range zone.tokenForms() {
+		if f.Get("grant_type") == "urn:ietf:params:oauth:grant-type:token-exchange" {
+			exchange = f
+		}
+	}
+	if exchange == nil {
+		t.Fatalf("no token-exchange request reached the zone; forms=%v", zone.tokenForms())
+	}
+	if got := exchange.Get("scope"); got != "read write" {
+		t.Errorf("scope: got %q, want %q", got, "read write")
+	}
+}
+
+func TestGrant_UserIdentifierImpersonates(t *testing.T) {
+	zone := newGrantTokenServer(t)
+	provider := newSingleZoneProvider(t, zone.URL)
+
+	resolved := false
+	ac := runGrant(t, zone.URL, "user-token",
+		provider.Grant([]string{"https://api.example.com"},
+			WithUserIdentifier(func(_ *http.Request) (string, error) {
+				resolved = true
+				return "user-42", nil
+			}),
+		))
+
+	if !resolved {
+		t.Error("user identifier resolver was not called")
+	}
+	if ac.Status() != StatusSuccess {
+		t.Fatalf("status: got %q, want success", ac.Status())
+	}
+
+	// Impersonation performs the exchange as a substitute-user, not the caller's token.
+	sawSubstituteUser := false
+	for _, f := range zone.tokenForms() {
+		if f.Get("subject_token_type") == oauth.SubstituteUserTokenType {
+			sawSubstituteUser = true
+		}
+	}
+	if !sawSubstituteUser {
+		t.Errorf("expected a substitute-user exchange (impersonation); forms=%v", zone.tokenForms())
+	}
+}
+
+func TestGrant_UserIdentifierErrorFailsClosed(t *testing.T) {
+	zone := newGrantTokenServer(t)
+	provider := newSingleZoneProvider(t, zone.URL)
+
+	ac := runGrant(t, zone.URL, "user-token",
+		provider.Grant([]string{"https://api.example.com"},
+			WithUserIdentifier(func(_ *http.Request) (string, error) {
+				return "", context.DeadlineExceeded
+			}),
+		))
+
+	if !ac.HasError() {
+		t.Error("expected a global error when the user-identifier resolver fails")
+	}
+	if n := len(zone.tokenForms()); n != 0 {
+		t.Errorf("token endpoint was hit %d times; a failed resolver must not exchange", n)
+	}
+}
+
+func TestGrant_StacksAndMerges(t *testing.T) {
+	zone := newGrantTokenServer(t)
+	provider := newSingleZoneProvider(t, zone.URL)
+
+	// Two stacked grants for different resources merge into one AccessContext.
+	inner := provider.Grant([]string{"https://b.example.com"})
+	outer := provider.Grant([]string{"https://a.example.com"})
+
+	ac := runGrant(t, zone.URL, "user-token", func(next http.Handler) http.Handler {
+		return outer(inner(next))
+	})
+
+	if ac.Status() != StatusSuccess {
+		t.Fatalf("status: got %q, want success", ac.Status())
+	}
+	if _, err := ac.Access("https://a.example.com"); err != nil {
+		t.Errorf("resource a: %v", err)
+	}
+	if _, err := ac.Access("https://b.example.com"); err != nil {
+		t.Errorf("resource b: %v", err)
+	}
+}

--- a/mcp/grant_test.go
+++ b/mcp/grant_test.go
@@ -99,6 +99,37 @@ func TestGrant_RequestScopes(t *testing.T) {
 	}
 }
 
+func TestGrant_RequestScopesByResource(t *testing.T) {
+	zone := newGrantTokenServer(t)
+	provider := newSingleZoneProvider(t, zone.URL)
+
+	ac := runGrant(t, zone.URL, "user-token",
+		provider.Grant(
+			[]string{"https://a.example.com", "https://b.example.com"},
+			WithRequestScopes("default.scope"), // fallback for resources not in the map
+			WithRequestScopesByResource(map[string][]string{
+				"https://a.example.com": {"a.read", "a.write"},
+			}),
+		))
+
+	if ac.Status() != StatusSuccess {
+		t.Fatalf("status: got %q, want success", ac.Status())
+	}
+
+	byResource := map[string]string{}
+	for _, f := range zone.tokenForms() {
+		if f.Get("grant_type") == "urn:ietf:params:oauth:grant-type:token-exchange" {
+			byResource[f.Get("resource")] = f.Get("scope")
+		}
+	}
+	if got := byResource["https://a.example.com"]; got != "a.read a.write" {
+		t.Errorf("resource a scope: got %q, want %q (per-resource)", got, "a.read a.write")
+	}
+	if got := byResource["https://b.example.com"]; got != "default.scope" {
+		t.Errorf("resource b scope: got %q, want %q (falls back to flat)", got, "default.scope")
+	}
+}
+
 func TestGrant_UserIdentifierImpersonates(t *testing.T) {
 	zone := newGrantTokenServer(t)
 	provider := newSingleZoneProvider(t, zone.URL)

--- a/mcp/grant_test.go
+++ b/mcp/grant_test.go
@@ -110,6 +110,7 @@ func TestGrant_UserIdentifierImpersonates(t *testing.T) {
 				resolved = true
 				return "user-42", nil
 			}),
+			WithRequestScopes("inventory.read"),
 		))
 
 	if !resolved {
@@ -119,15 +120,19 @@ func TestGrant_UserIdentifierImpersonates(t *testing.T) {
 		t.Fatalf("status: got %q, want success", ac.Status())
 	}
 
-	// Impersonation performs the exchange as a substitute-user, not the caller's token.
-	sawSubstituteUser := false
+	// Impersonation performs the exchange as a substitute-user (not the caller's token),
+	// and the requested scopes reach that exchange.
+	var substituteUser url.Values
 	for _, f := range zone.tokenForms() {
 		if f.Get("subject_token_type") == oauth.SubstituteUserTokenType {
-			sawSubstituteUser = true
+			substituteUser = f
 		}
 	}
-	if !sawSubstituteUser {
-		t.Errorf("expected a substitute-user exchange (impersonation); forms=%v", zone.tokenForms())
+	if substituteUser == nil {
+		t.Fatalf("expected a substitute-user exchange (impersonation); forms=%v", zone.tokenForms())
+	}
+	if got := substituteUser.Get("scope"); got != "inventory.read" {
+		t.Errorf("impersonation scope: got %q, want %q", got, "inventory.read")
 	}
 }
 

--- a/mcp/multizone_test.go
+++ b/mcp/multizone_test.go
@@ -241,7 +241,7 @@ func TestAuthProvider_GrantRoutesByTokenIssuer(t *testing.T) {
 	}
 
 	handler := RequireBearerAuth(verifier)(
-		provider.Grant("https://api.example.com")(
+		provider.Grant([]string{"https://api.example.com"})(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				ac := AccessContextFromRequest(r)
 				if _, err := ac.Access("https://api.example.com"); err != nil {

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -6,150 +6,29 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/keycardai/credentials-go/oauth"
 )
 
-// AccessContextStatus represents the status of token exchanges.
-type AccessContextStatus string
-
-const (
-	StatusSuccess      AccessContextStatus = "success"
-	StatusPartialError AccessContextStatus = "partial_error"
-	StatusError        AccessContextStatus = "error"
+// AccessContext, its status/error types, and ResourceAccessError now live in the oauth
+// package, so the oauth client surface can return them without importing mcp. They are
+// re-exported here as aliases for backward compatibility.
+type (
+	AccessContext       = oauth.AccessContext
+	AccessContextStatus = oauth.AccessContextStatus
+	ErrorDetail         = oauth.ErrorDetail
 )
 
-// ErrorDetail describes an error during token exchange.
-type ErrorDetail struct {
-	Message     string `json:"message"`
-	Code        string `json:"code,omitempty"`
-	Description string `json:"description,omitempty"`
-	RawError    string `json:"raw_error,omitempty"`
-}
-
-// AccessContext holds the results of token exchanges for multiple resources.
-// It is a non-throwing result container: callers check status before accessing tokens.
-type AccessContext struct {
-	tokens         map[string]*oauth.TokenResponse
-	resourceErrors map[string]ErrorDetail
-	globalError    *ErrorDetail
-}
+const (
+	StatusSuccess      = oauth.StatusSuccess
+	StatusPartialError = oauth.StatusPartialError
+	StatusError        = oauth.StatusError
+)
 
 // NewAccessContext creates a new empty AccessContext.
-func NewAccessContext() *AccessContext {
-	return &AccessContext{
-		tokens:         make(map[string]*oauth.TokenResponse),
-		resourceErrors: make(map[string]ErrorDetail),
-	}
-}
-
-// SetToken sets a successful token for a resource (clears any error for that resource).
-func (ac *AccessContext) SetToken(resource string, token *oauth.TokenResponse) {
-	ac.tokens[resource] = token
-	delete(ac.resourceErrors, resource)
-}
-
-// SetBulkTokens sets multiple tokens at once.
-func (ac *AccessContext) SetBulkTokens(tokens map[string]*oauth.TokenResponse) {
-	for resource, token := range tokens {
-		ac.tokens[resource] = token
-	}
-}
-
-// SetResourceError sets an error for a specific resource (clears any token for that resource).
-func (ac *AccessContext) SetResourceError(resource string, detail ErrorDetail) {
-	ac.resourceErrors[resource] = detail
-	delete(ac.tokens, resource)
-}
-
-// SetError sets a global error.
-func (ac *AccessContext) SetError(detail ErrorDetail) {
-	ac.globalError = &detail
-}
-
-// Access returns the token for the given resource.
-// Returns ResourceAccessError if the resource has an error or no token.
-func (ac *AccessContext) Access(resource string) (*oauth.TokenResponse, error) {
-	if ac.globalError != nil {
-		return nil, &ResourceAccessError{Message: ac.globalError.Message}
-	}
-	if _, hasErr := ac.resourceErrors[resource]; hasErr {
-		return nil, &ResourceAccessError{Message: ac.resourceErrors[resource].Message}
-	}
-	token, ok := ac.tokens[resource]
-	if !ok {
-		return nil, &ResourceAccessError{Message: fmt.Sprintf("no token for resource %q", resource)}
-	}
-	return token, nil
-}
-
-// Status returns the overall status of the context.
-func (ac *AccessContext) Status() AccessContextStatus {
-	if ac.globalError != nil {
-		return StatusError
-	}
-	if len(ac.resourceErrors) > 0 {
-		return StatusPartialError
-	}
-	return StatusSuccess
-}
-
-// HasErrors returns true if any errors occurred (global or per-resource).
-func (ac *AccessContext) HasErrors() bool {
-	return ac.globalError != nil || len(ac.resourceErrors) > 0
-}
-
-// HasError returns true if a global error is set.
-func (ac *AccessContext) HasError() bool {
-	return ac.globalError != nil
-}
-
-// HasResourceError returns true if the specific resource had an error.
-func (ac *AccessContext) HasResourceError(resource string) bool {
-	_, ok := ac.resourceErrors[resource]
-	return ok
-}
-
-// GetError returns the global error, or nil.
-func (ac *AccessContext) GetError() *ErrorDetail {
-	return ac.globalError
-}
-
-// GetResourceError returns the error for a specific resource, or nil.
-func (ac *AccessContext) GetResourceError(resource string) *ErrorDetail {
-	if detail, ok := ac.resourceErrors[resource]; ok {
-		return &detail
-	}
-	return nil
-}
-
-// GetErrors returns all errors (global + per-resource).
-func (ac *AccessContext) GetErrors() (resources map[string]ErrorDetail, globalError *ErrorDetail) {
-	result := make(map[string]ErrorDetail, len(ac.resourceErrors))
-	for k, v := range ac.resourceErrors {
-		result[k] = v
-	}
-	return result, ac.globalError
-}
-
-// SuccessfulResources returns the list of resources with successful token exchanges.
-func (ac *AccessContext) SuccessfulResources() []string {
-	resources := make([]string, 0, len(ac.tokens))
-	for r := range ac.tokens {
-		resources = append(resources, r)
-	}
-	return resources
-}
-
-// FailedResources returns the list of resources with failed token exchanges.
-func (ac *AccessContext) FailedResources() []string {
-	resources := make([]string, 0, len(ac.resourceErrors))
-	for r := range ac.resourceErrors {
-		resources = append(resources, r)
-	}
-	return resources
-}
+func NewAccessContext() *AccessContext { return oauth.NewAccessContext() }
 
 // AuthProviderOption configures an AuthProvider.
 type AuthProviderOption func(*authProviderConfig)
@@ -244,49 +123,99 @@ func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 	return p, nil
 }
 
-// Grant returns middleware that performs token exchange for the specified resources.
-// The AccessContext is stored in the request context (retrieve with AccessContextFromRequest).
-func (p *AuthProvider) Grant(resources ...string) func(http.Handler) http.Handler {
+// GrantOption configures the token exchange that Grant performs.
+type GrantOption func(*grantConfig)
+
+type grantConfig struct {
+	userIdentifier func(*http.Request) (string, error)
+	requestScopes  []string
+}
+
+// WithUserIdentifier sets a resolver that maps the inbound request to a user identifier.
+// When set, Grant impersonates that user (RFC 8693 substitute-user) for each resource
+// rather than exchanging the caller's own token. The resolver runs once per request; if it
+// returns an error the grant fails closed with a global error on the AccessContext.
+func WithUserIdentifier(fn func(*http.Request) (string, error)) GrantOption {
+	return func(c *grantConfig) { c.userIdentifier = fn }
+}
+
+// WithRequestScopes sets the scopes requested for each resource's exchanged token.
+func WithRequestScopes(scopes ...string) GrantOption {
+	return func(c *grantConfig) { c.requestScopes = scopes }
+}
+
+// Grant returns middleware that performs token exchange for the specified resources and
+// stores the result in the request context (retrieve with AccessContextFromRequest).
+// Stacked Grant middlewares merge into a single AccessContext on the request. With
+// WithUserIdentifier the grant impersonates the resolved user instead of exchanging the
+// caller's token.
+func (p *AuthProvider) Grant(resources []string, opts ...GrantOption) func(http.Handler) http.Handler {
+	cfg := grantConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authInfo := AuthInfoFromRequest(r)
-
 			if authInfo == nil || authInfo.Token == "" {
-				ac := NewAccessContext()
-				ac.SetError(ErrorDetail{
+				ac := oauth.NewAccessContext()
+				ac.SetError(oauth.ErrorDetail{
 					Message: "No authentication token available. Ensure RequireBearerAuth() middleware runs before Grant().",
 				})
-				ctx := context.WithValue(r.Context(), accessContextKey, ac)
-				next.ServeHTTP(w, r.WithContext(ctx))
+				next.ServeHTTP(w, r.WithContext(mergeAccessContext(r, ac)))
 				return
 			}
 
-			ac := p.exchange(r.Context(), authInfo.Issuer, authInfo.Token, resources...)
-			ctx := context.WithValue(r.Context(), accessContextKey, ac)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			userIdentifier := ""
+			if cfg.userIdentifier != nil {
+				id, err := cfg.userIdentifier(r)
+				if err != nil {
+					ac := oauth.NewAccessContext()
+					ac.SetError(oauth.ErrorDetail{
+						Message:  "Failed to resolve the user identifier for impersonation.",
+						RawError: err.Error(),
+					})
+					next.ServeHTTP(w, r.WithContext(mergeAccessContext(r, ac)))
+					return
+				}
+				userIdentifier = id
+			}
+
+			ac := p.exchange(r.Context(), authInfo.Issuer, authInfo.Token, userIdentifier, cfg.requestScopes, resources)
+			next.ServeHTTP(w, r.WithContext(mergeAccessContext(r, ac)))
 		})
 	}
+}
+
+// mergeAccessContext folds ac into the request's existing AccessContext when one is
+// present (stacked grants), otherwise attaches ac to the request context.
+func mergeAccessContext(r *http.Request, ac *oauth.AccessContext) context.Context {
+	if existing := AccessContextFromRequest(r); existing != nil {
+		existing.Merge(ac)
+		return r.Context()
+	}
+	return context.WithValue(r.Context(), accessContextKey, ac)
 }
 
 // ExchangeTokens performs token exchange for a single-zone provider and returns an
 // AccessContext. For a multi-zone provider use ExchangeTokensForZone, or Grant (which
 // routes by the verified token's issuer).
 func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, resources ...string) *AccessContext {
-	return p.exchange(ctx, "", subjectToken, resources...)
+	return p.exchange(ctx, "", subjectToken, "", nil, resources)
 }
 
 // ExchangeTokensForZone performs token exchange against the given zone (issuer URL),
 // selecting that zone's credential. It fails closed if the zone is not configured.
 func (p *AuthProvider) ExchangeTokensForZone(ctx context.Context, issuer, subjectToken string, resources ...string) *AccessContext {
-	return p.exchange(ctx, issuer, subjectToken, resources...)
+	return p.exchange(ctx, issuer, subjectToken, "", nil, resources)
 }
 
-func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken string, resources ...string) *AccessContext {
-	ac := NewAccessContext()
+func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken, userIdentifier string, scopes, resources []string) *AccessContext {
+	ac := oauth.NewAccessContext()
 
 	zone, err := p.resolveZone(issuer)
 	if err != nil {
-		ac.SetError(ErrorDetail{
+		ac.SetError(oauth.ErrorDetail{
 			Message:  "Could not resolve the request's zone.",
 			RawError: err.Error(),
 		})
@@ -295,61 +224,78 @@ func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken string
 
 	client := p.clientForZone(zone)
 	if client == nil {
-		ac.SetError(ErrorDetail{
+		ac.SetError(oauth.ErrorDetail{
 			Message:  "Could not resolve the request's zone.",
 			RawError: fmt.Sprintf("no token-exchange client for zone %q", zone),
 		})
 		return ac
 	}
-	tokens := make(map[string]*oauth.TokenResponse)
 
 	// Resolve the token endpoint for credential assertion audience.
 	tokenEndpoint, _ := client.TokenEndpoint(ctx)
 
+	tokens := make(map[string]*oauth.TokenResponse)
 	for _, resource := range resources {
-		var req *oauth.TokenExchangeRequest
-
-		if p.credential != nil {
-			opts := &PrepareOptions{TokenEndpoint: tokenEndpoint}
-			req, err = p.credential.PrepareTokenExchangeRequest(ctx, subjectToken, resource, opts)
-			if err != nil {
-				ac.SetResourceError(resource, ErrorDetail{
-					Message:  fmt.Sprintf("Token exchange failed for %s", resource),
-					RawError: err.Error(),
-				})
-				continue
-			}
-		} else {
-			req = &oauth.TokenExchangeRequest{
-				SubjectToken:     subjectToken,
-				Resource:         resource,
-				SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
-			}
-		}
-
-		resp, err := client.ExchangeToken(ctx, *req)
+		resp, err := p.exchangeResource(ctx, client, subjectToken, userIdentifier, scopes, resource, tokenEndpoint)
 		if err != nil {
-			detail := ErrorDetail{
-				Message: fmt.Sprintf("Token exchange failed for %s", resource),
-			}
-			var oauthErr *oauth.OAuthError
-			if errors.As(err, &oauthErr) {
-				detail.Code = oauthErr.ErrorCode
-				if oauthErr.Message != "" {
-					detail.Description = oauthErr.Message
-				}
-			} else {
-				detail.RawError = err.Error()
-			}
-			ac.SetResourceError(resource, detail)
+			ac.SetResourceError(resource, exchangeErrorDetail(resource, err))
 			continue
 		}
-
 		tokens[resource] = resp
 	}
 
 	ac.SetBulkTokens(tokens)
 	return ac
+}
+
+// exchangeResource exchanges (or impersonates) a single resource token. With a
+// userIdentifier it performs an RFC 8693 substitute-user impersonation; otherwise it
+// exchanges the caller's subject token, building the request via the application
+// credential when one is configured.
+func (p *AuthProvider) exchangeResource(ctx context.Context, client *oauth.TokenExchangeClient, subjectToken, userIdentifier string, scopes []string, resource, tokenEndpoint string) (*oauth.TokenResponse, error) {
+	if userIdentifier != "" {
+		return client.Impersonate(ctx, oauth.ImpersonateRequest{
+			UserIdentifier: userIdentifier,
+			Resource:       resource,
+			Scopes:         scopes,
+		})
+	}
+
+	var req *oauth.TokenExchangeRequest
+	if p.credential != nil {
+		r, err := p.credential.PrepareTokenExchangeRequest(ctx, subjectToken, resource, &PrepareOptions{TokenEndpoint: tokenEndpoint})
+		if err != nil {
+			return nil, err
+		}
+		req = r
+	} else {
+		req = &oauth.TokenExchangeRequest{
+			SubjectToken:     subjectToken,
+			Resource:         resource,
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		}
+	}
+	if len(scopes) > 0 {
+		req.Scope = strings.Join(scopes, " ")
+	}
+
+	return client.ExchangeToken(ctx, *req)
+}
+
+// exchangeErrorDetail builds an ErrorDetail from a failed exchange, surfacing an OAuth
+// error's code/description when present and otherwise the raw error.
+func exchangeErrorDetail(resource string, err error) oauth.ErrorDetail {
+	detail := oauth.ErrorDetail{Message: fmt.Sprintf("Token exchange failed for %s", resource)}
+	var oauthErr *oauth.OAuthError
+	if errors.As(err, &oauthErr) {
+		detail.Code = oauthErr.ErrorCode
+		if oauthErr.Message != "" {
+			detail.Description = oauthErr.Message
+		}
+	} else {
+		detail.RawError = err.Error()
+	}
+	return detail
 }
 
 // resolveZone picks the zone issuer URL for an exchange. A single-zone provider always

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -127,8 +127,9 @@ func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 type GrantOption func(*grantConfig)
 
 type grantConfig struct {
-	userIdentifier func(*http.Request) (string, error)
-	requestScopes  []string
+	userIdentifier          func(*http.Request) (string, error)
+	requestScopes           []string
+	requestScopesByResource map[string][]string
 }
 
 // WithUserIdentifier sets a resolver that maps the inbound request to a user identifier.
@@ -149,10 +150,17 @@ func WithUserIdentifier(fn func(*http.Request) (string, error)) GrantOption {
 
 // WithRequestScopes sets the scopes requested for each resource's exchanged token. The
 // same scopes apply to every resource in the grant and take precedence over any scope the
-// application credential sets. To request different scopes per resource, stack a
-// single-resource Grant for each.
+// application credential sets. Use WithRequestScopesByResource to vary scopes per resource.
 func WithRequestScopes(scopes ...string) GrantOption {
 	return func(c *grantConfig) { c.requestScopes = scopes }
+}
+
+// WithRequestScopesByResource sets the scopes requested per resource, keyed by resource
+// URL. A resource present in the map uses its scopes; a resource absent from the map falls
+// back to WithRequestScopes (if set). This mirrors the per-resource form of the TypeScript
+// requestScopes option.
+func WithRequestScopesByResource(scopes map[string][]string) GrantOption {
+	return func(c *grantConfig) { c.requestScopesByResource = scopes }
 }
 
 // Grant returns middleware that performs token exchange for the specified resources and
@@ -192,7 +200,7 @@ func (p *AuthProvider) Grant(resources []string, opts ...GrantOption) func(http.
 				userIdentifier = id
 			}
 
-			ac := p.exchange(r.Context(), authInfo.Issuer, authInfo.Token, userIdentifier, cfg.requestScopes, resources)
+			ac := p.exchange(r.Context(), authInfo.Issuer, authInfo.Token, userIdentifier, cfg.requestScopes, cfg.requestScopesByResource, resources)
 			next.ServeHTTP(w, r.WithContext(mergeAccessContext(r, ac)))
 		})
 	}
@@ -212,16 +220,16 @@ func mergeAccessContext(r *http.Request, ac *oauth.AccessContext) context.Contex
 // AccessContext. For a multi-zone provider use ExchangeTokensForZone, or Grant (which
 // routes by the verified token's issuer).
 func (p *AuthProvider) ExchangeTokens(ctx context.Context, subjectToken string, resources ...string) *AccessContext {
-	return p.exchange(ctx, "", subjectToken, "", nil, resources)
+	return p.exchange(ctx, "", subjectToken, "", nil, nil, resources)
 }
 
 // ExchangeTokensForZone performs token exchange against the given zone (issuer URL),
 // selecting that zone's credential. It fails closed if the zone is not configured.
 func (p *AuthProvider) ExchangeTokensForZone(ctx context.Context, issuer, subjectToken string, resources ...string) *AccessContext {
-	return p.exchange(ctx, issuer, subjectToken, "", nil, resources)
+	return p.exchange(ctx, issuer, subjectToken, "", nil, nil, resources)
 }
 
-func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken, userIdentifier string, scopes, resources []string) *AccessContext {
+func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken, userIdentifier string, scopes []string, scopesByResource map[string][]string, resources []string) *AccessContext {
 	ac := oauth.NewAccessContext()
 
 	zone, err := p.resolveZone(issuer)
@@ -247,7 +255,11 @@ func (p *AuthProvider) exchange(ctx context.Context, issuer, subjectToken, userI
 
 	tokens := make(map[string]*oauth.TokenResponse)
 	for _, resource := range resources {
-		resp, err := p.exchangeResource(ctx, client, subjectToken, userIdentifier, scopes, resource, tokenEndpoint)
+		resourceScopes := scopes
+		if s, ok := scopesByResource[resource]; ok {
+			resourceScopes = s
+		}
+		resp, err := p.exchangeResource(ctx, client, subjectToken, userIdentifier, resourceScopes, resource, tokenEndpoint)
 		if err != nil {
 			ac.SetResourceError(resource, exchangeErrorDetail(resource, err))
 			continue

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -135,11 +135,22 @@ type grantConfig struct {
 // When set, Grant impersonates that user (RFC 8693 substitute-user) for each resource
 // rather than exchanging the caller's own token. The resolver runs once per request; if it
 // returns an error the grant fails closed with a global error on the AccessContext.
+//
+// SECURITY: the resolved identifier becomes the subject of a real token minted with the
+// agent's own credential. Derive it from the verified token, never from unverified request
+// data such as a header, query parameter, or body field:
+//
+//	mcp.WithUserIdentifier(func(r *http.Request) (string, error) {
+//		return mcp.AuthInfoFromRequest(r).Subject, nil
+//	})
 func WithUserIdentifier(fn func(*http.Request) (string, error)) GrantOption {
 	return func(c *grantConfig) { c.userIdentifier = fn }
 }
 
-// WithRequestScopes sets the scopes requested for each resource's exchanged token.
+// WithRequestScopes sets the scopes requested for each resource's exchanged token. The
+// same scopes apply to every resource in the grant and take precedence over any scope the
+// application credential sets. To request different scopes per resource, stack a
+// single-resource Grant for each.
 func WithRequestScopes(scopes ...string) GrantOption {
 	return func(c *grantConfig) { c.requestScopes = scopes }
 }

--- a/mcp/verifier.go
+++ b/mcp/verifier.go
@@ -8,8 +8,11 @@ import (
 
 // AuthInfo contains information about an authenticated request.
 type AuthInfo struct {
-	Token     string
-	ClientID  string
+	Token    string
+	ClientID string
+	// Subject is the verified token's sub claim: the authenticated user. Use it as the
+	// trusted identity for impersonation (see WithUserIdentifier).
+	Subject   string
 	Scopes    []string
 	Resource  string
 	ExpiresAt int64
@@ -68,6 +71,7 @@ func (v *JWTOAuthTokenVerifier) VerifyAccessToken(ctx context.Context, token str
 	info := &AuthInfo{
 		Token:    token,
 		ClientID: claims.ClientID,
+		Subject:  claims.Subject,
 		Scopes:   parseScopes(claims.Scope),
 		Issuer:   claims.Issuer,
 	}

--- a/oauth/access_context.go
+++ b/oauth/access_context.go
@@ -1,0 +1,175 @@
+package oauth
+
+import "fmt"
+
+// AccessContextStatus represents the overall status of a set of token exchanges.
+type AccessContextStatus string
+
+const (
+	StatusSuccess      AccessContextStatus = "success"
+	StatusPartialError AccessContextStatus = "partial_error"
+	StatusError        AccessContextStatus = "error"
+)
+
+// ErrorDetail describes an error during token exchange.
+type ErrorDetail struct {
+	Message     string `json:"message"`
+	Code        string `json:"code,omitempty"`
+	Description string `json:"description,omitempty"`
+	RawError    string `json:"raw_error,omitempty"`
+}
+
+// ResourceAccessError is returned when a resource's token is unavailable.
+type ResourceAccessError struct {
+	Message string
+}
+
+func (e *ResourceAccessError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return "resource access error"
+}
+
+func (*ResourceAccessError) keycardError() {}
+
+// AccessContext holds the results of token exchanges for multiple resources. It is a
+// non-throwing result container: callers check status before accessing tokens.
+type AccessContext struct {
+	tokens         map[string]*TokenResponse
+	resourceErrors map[string]ErrorDetail
+	globalError    *ErrorDetail
+}
+
+// NewAccessContext creates a new empty AccessContext.
+func NewAccessContext() *AccessContext {
+	return &AccessContext{
+		tokens:         make(map[string]*TokenResponse),
+		resourceErrors: make(map[string]ErrorDetail),
+	}
+}
+
+// SetToken sets a successful token for a resource (clears any error for that resource).
+func (ac *AccessContext) SetToken(resource string, token *TokenResponse) {
+	ac.tokens[resource] = token
+	delete(ac.resourceErrors, resource)
+}
+
+// SetBulkTokens sets multiple tokens at once.
+func (ac *AccessContext) SetBulkTokens(tokens map[string]*TokenResponse) {
+	for resource, token := range tokens {
+		ac.tokens[resource] = token
+	}
+}
+
+// SetResourceError sets an error for a specific resource (clears any token for that resource).
+func (ac *AccessContext) SetResourceError(resource string, detail ErrorDetail) {
+	ac.resourceErrors[resource] = detail
+	delete(ac.tokens, resource)
+}
+
+// SetError sets a global error.
+func (ac *AccessContext) SetError(detail ErrorDetail) {
+	ac.globalError = &detail
+}
+
+// Merge folds another AccessContext into this one, for stacked grants. Tokens and
+// resource errors from other are applied entry by entry (preserving the token-or-error
+// invariant per resource); other's global error is adopted only if this one has none.
+func (ac *AccessContext) Merge(other *AccessContext) {
+	if other == nil {
+		return
+	}
+	for resource, token := range other.tokens {
+		ac.SetToken(resource, token)
+	}
+	for resource, detail := range other.resourceErrors {
+		ac.SetResourceError(resource, detail)
+	}
+	if ac.globalError == nil && other.globalError != nil {
+		ac.globalError = other.globalError
+	}
+}
+
+// Access returns the token for the given resource, or a *ResourceAccessError if the
+// resource has an error or no token.
+func (ac *AccessContext) Access(resource string) (*TokenResponse, error) {
+	if ac.globalError != nil {
+		return nil, &ResourceAccessError{Message: ac.globalError.Message}
+	}
+	if _, hasErr := ac.resourceErrors[resource]; hasErr {
+		return nil, &ResourceAccessError{Message: ac.resourceErrors[resource].Message}
+	}
+	token, ok := ac.tokens[resource]
+	if !ok {
+		return nil, &ResourceAccessError{Message: fmt.Sprintf("no token for resource %q", resource)}
+	}
+	return token, nil
+}
+
+// Status returns the overall status of the context.
+func (ac *AccessContext) Status() AccessContextStatus {
+	if ac.globalError != nil {
+		return StatusError
+	}
+	if len(ac.resourceErrors) > 0 {
+		return StatusPartialError
+	}
+	return StatusSuccess
+}
+
+// HasErrors returns true if any errors occurred (global or per-resource).
+func (ac *AccessContext) HasErrors() bool {
+	return ac.globalError != nil || len(ac.resourceErrors) > 0
+}
+
+// HasError returns true if a global error is set.
+func (ac *AccessContext) HasError() bool {
+	return ac.globalError != nil
+}
+
+// HasResourceError returns true if the specific resource had an error.
+func (ac *AccessContext) HasResourceError(resource string) bool {
+	_, ok := ac.resourceErrors[resource]
+	return ok
+}
+
+// GetError returns the global error, or nil.
+func (ac *AccessContext) GetError() *ErrorDetail {
+	return ac.globalError
+}
+
+// GetResourceError returns the error for a specific resource, or nil.
+func (ac *AccessContext) GetResourceError(resource string) *ErrorDetail {
+	if detail, ok := ac.resourceErrors[resource]; ok {
+		return &detail
+	}
+	return nil
+}
+
+// GetErrors returns all errors (global + per-resource).
+func (ac *AccessContext) GetErrors() (resources map[string]ErrorDetail, globalError *ErrorDetail) {
+	result := make(map[string]ErrorDetail, len(ac.resourceErrors))
+	for k, v := range ac.resourceErrors {
+		result[k] = v
+	}
+	return result, ac.globalError
+}
+
+// SuccessfulResources returns the list of resources with successful token exchanges.
+func (ac *AccessContext) SuccessfulResources() []string {
+	resources := make([]string, 0, len(ac.tokens))
+	for r := range ac.tokens {
+		resources = append(resources, r)
+	}
+	return resources
+}
+
+// FailedResources returns the list of resources with failed token exchanges.
+func (ac *AccessContext) FailedResources() []string {
+	resources := make([]string, 0, len(ac.resourceErrors))
+	for r := range ac.resourceErrors {
+		resources = append(resources, r)
+	}
+	return resources
+}

--- a/oauth/access_context.go
+++ b/oauth/access_context.go
@@ -75,7 +75,8 @@ func (ac *AccessContext) SetError(detail ErrorDetail) {
 
 // Merge folds another AccessContext into this one, for stacked grants. Tokens and
 // resource errors from other are applied entry by entry (preserving the token-or-error
-// invariant per resource); other's global error is adopted only if this one has none.
+// invariant per resource); other's global error overwrites this one (last-wins, matching
+// the TypeScript convention).
 func (ac *AccessContext) Merge(other *AccessContext) {
 	if other == nil {
 		return
@@ -86,7 +87,7 @@ func (ac *AccessContext) Merge(other *AccessContext) {
 	for resource, detail := range other.resourceErrors {
 		ac.SetResourceError(resource, detail)
 	}
-	if ac.globalError == nil && other.globalError != nil {
+	if other.globalError != nil {
 		ac.globalError = other.globalError
 	}
 }

--- a/oauth/access_context_test.go
+++ b/oauth/access_context_test.go
@@ -1,0 +1,39 @@
+package oauth
+
+import "testing"
+
+func TestAccessContext_MergeTokensAndErrors(t *testing.T) {
+	a := NewAccessContext()
+	a.SetToken("res-a", &TokenResponse{AccessToken: "ta"})
+
+	b := NewAccessContext()
+	b.SetToken("res-b", &TokenResponse{AccessToken: "tb"})
+	b.SetResourceError("res-c", ErrorDetail{Message: "failed"})
+
+	a.Merge(b)
+
+	if _, err := a.Access("res-a"); err != nil {
+		t.Errorf("res-a: %v", err)
+	}
+	if _, err := a.Access("res-b"); err != nil {
+		t.Errorf("res-b: %v", err)
+	}
+	if !a.HasResourceError("res-c") {
+		t.Error("res-c error was not merged")
+	}
+}
+
+// Merge is last-wins on the global error, matching the TypeScript convention.
+func TestAccessContext_MergeGlobalErrorLastWins(t *testing.T) {
+	a := NewAccessContext()
+	a.SetError(ErrorDetail{Message: "first"})
+
+	b := NewAccessContext()
+	b.SetError(ErrorDetail{Message: "second"})
+
+	a.Merge(b)
+
+	if got := a.GetError(); got == nil || got.Message != "second" {
+		t.Errorf("global error after merge: got %+v, want last-wins %q", got, "second")
+	}
+}


### PR DESCRIPTION
## What

Two ECO-94 items, completing the checklist alongside #25 (WithPublicJWKS):

### 1. Move `AccessContext` to `oauth` (source-compatible)
`AccessContext`, `AccessContextStatus`, `ErrorDetail`, and `ResourceAccessError` move from `mcp` to a new `oauth/access_context.go`, so the `oauth` client surface can return them without importing `mcp` (recon confirmed `oauth` does not import `mcp`, no cycle). `mcp` re-exports all four as **type aliases**, so every existing `mcp.AccessContext` / `mcp.NewAccessContext` / `mcp.ErrorDetail` / `mcp.ResourceAccessError` usage keeps compiling — **not a source break**. This matches the Python/TS layout (AccessContext lives in oauth). Adds `AccessContext.Merge` (TS has it; used for stacked grants).

### 2. Grant decorator
`AuthProvider.Grant` gains options, mirroring the TS `grant(resources, options)` middleware:
- **`WithUserIdentifier(func(*http.Request) (string, error))`** — impersonate the resolved user (RFC 8693 substitute-user, via the existing `oauth.Impersonate`) for each resource instead of exchanging the caller's token. A resolver error fails the grant closed (global error, no exchange).
- **`WithRequestScopes(...)`** — scopes requested for each resource's exchanged token.
- **Stacked grants merge** into a single `AccessContext` on the request.

## Breaking change

`Grant(resources ...string)` → **`Grant(resources []string, opts ...GrantOption)`** (idiomatic Go for "list + options"; you OK'd breaking). The two examples are updated:

```go
authProvider.Grant([]string{"https://api.example.com"},
    mcp.WithUserIdentifier(func(r *http.Request) (string, error) { return userIDFrom(r), nil }),
    mcp.WithRequestScopes("read", "write"),
)
```

## Verify

- `go build ./... ./examples/...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./...` — the whole existing suite passes unchanged (proves the move is source-compatible via aliases), plus new `mcp/grant_test.go`:
  - `WithRequestScopes` → the exchange carries `scope`
  - `WithUserIdentifier` → a substitute-user (impersonation) exchange, not the caller's token
  - resolver error → fails closed, no token request
  - stacked grants → one merged `AccessContext` with both resources

## Notes

- Followed the `Err`/`Unwrap()` convention for `ResourceAccessError` (it now carries the oauth `keycardError()` marker).
- The `delegated-access` example exercises `Grant`; a dedicated impersonation-via-Grant example can follow if you want one.
- Unrelated: `examples/impersonation/main.go` is still gofmt-dirty on main (pre-existing); left out of this PR — happy to clean it in a one-liner.

Linear: ECO-94 (with #25 merged, this closes the ECO-94 checklist).