### PR TITLE
feat(mcp)!: tighten WebIdentity assertion + storage; add seed AccessContext (ECO-94)

### DIFF
--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -165,8 +165,10 @@ func WithKeyID(kid string) WebIdentityOption {
 
 // WithClientID sets the registered OAuth client id used as the assertion's iss and sub
 // claims. A request-time resource_client_id (from the exchange auth context) overrides it.
-// The client id is required to prepare a token exchange (there is no key-id fallback), so
-// set it here or supply resource_client_id at request time.
+// The client id is required to prepare a token exchange (there is no key-id fallback). It
+// is effectively mandatory when the credential is used with AuthProvider, which does not
+// supply resource_client_id at request time; NewAuthProvider rejects a WebIdentity
+// credential built without it.
 func WithClientID(clientID string) WebIdentityOption {
 	return func(cfg *webIdentityConfig) { cfg.clientID = clientID }
 }

--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -123,7 +123,9 @@ func (c *ClientSecretCredential) PrepareTokenExchangeRequest(_ context.Context, 
 
 // WebIdentityCredential implements ApplicationCredential using RFC 7523 private_key_jwt.
 type WebIdentityCredential struct {
-	keyManager *PrivateKeyManager
+	keyManager     *PrivateKeyManager
+	clientID       string
+	audienceConfig string
 
 	bootstrapOnce sync.Once
 	bootstrapErr  error
@@ -133,10 +135,12 @@ type WebIdentityCredential struct {
 type WebIdentityOption func(*webIdentityConfig)
 
 type webIdentityConfig struct {
-	serverName string
-	storage    PrivateKeyStorage
-	storageDir string
-	keyID      string
+	serverName     string
+	storage        PrivateKeyStorage
+	storageDir     string
+	keyID          string
+	clientID       string
+	audienceConfig string
 }
 
 // WithServerName sets the server name (used to derive key ID if not set).
@@ -159,20 +163,60 @@ func WithKeyID(kid string) WebIdentityOption {
 	return func(cfg *webIdentityConfig) { cfg.keyID = kid }
 }
 
+// WithClientID sets the registered OAuth client id used as the assertion's iss and sub
+// claims. A request-time resource_client_id (from the exchange auth context) overrides it.
+// The client id is required to prepare a token exchange (there is no key-id fallback), so
+// set it here or supply resource_client_id at request time.
+func WithClientID(clientID string) WebIdentityOption {
+	return func(cfg *webIdentityConfig) { cfg.clientID = clientID }
+}
+
+// WithAudienceConfig overrides the assertion audience. When unset, the audience is the
+// authorization server's token endpoint. (The per-zone audience map is part of the
+// multi-zone effort; this is the single-audience override.)
+func WithAudienceConfig(audience string) WebIdentityOption {
+	return func(cfg *webIdentityConfig) { cfg.audienceConfig = audience }
+}
+
 var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
+
+const (
+	defaultWebIdentityStorageDir = "./server_keys"
+	legacyWebIdentityStorageDir  = "./mcp_keys"
+)
+
+// resolveWebIdentityStorageDir returns the default key storage directory: ./server_keys,
+// falling back to the legacy ./mcp_keys when ./server_keys does not exist but ./mcp_keys does.
+func resolveWebIdentityStorageDir() string {
+	return chooseStorageDir(defaultWebIdentityStorageDir, legacyWebIdentityStorageDir)
+}
+
+func chooseStorageDir(defaultDir, legacyDir string) string {
+	if !dirExists(defaultDir) && dirExists(legacyDir) {
+		return legacyDir
+	}
+	return defaultDir
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
 
 // NewWebIdentity creates a new WebIdentityCredential with the given options.
 func NewWebIdentity(opts ...WebIdentityOption) *WebIdentityCredential {
-	cfg := webIdentityConfig{
-		storageDir: "./mcp_keys",
-	}
+	cfg := webIdentityConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
 	storage := cfg.storage
 	if storage == nil {
-		storage = NewFilePrivateKeyStorage(cfg.storageDir)
+		dir := cfg.storageDir
+		if dir == "" {
+			dir = resolveWebIdentityStorageDir()
+		}
+		storage = NewFilePrivateKeyStorage(dir)
 	}
 
 	keyID := cfg.keyID
@@ -184,7 +228,9 @@ func NewWebIdentity(opts ...WebIdentityOption) *WebIdentityCredential {
 	}
 
 	return &WebIdentityCredential{
-		keyManager: NewPrivateKeyManager(storage, keyID),
+		keyManager:     NewPrivateKeyManager(storage, keyID),
+		clientID:       cfg.clientID,
+		audienceConfig: cfg.audienceConfig,
 	}
 }
 
@@ -207,19 +253,29 @@ func (w *WebIdentityCredential) PrepareTokenExchangeRequest(ctx context.Context,
 		return nil, fmt.Errorf("bootstrapping identity: %w", err)
 	}
 
-	issuer := w.keyManager.ClientID()
+	// iss and sub are the registered OAuth client id: a request-time resource_client_id
+	// overrides the configured client id. There is no key-id fallback (RFC 7523).
+	clientID := w.clientID
 	if opts != nil && opts.AuthInfo != nil {
-		if resourceClientID, ok := opts.AuthInfo["resource_client_id"]; ok {
-			issuer = resourceClientID
+		if rcid, ok := opts.AuthInfo["resource_client_id"]; ok && rcid != "" {
+			clientID = rcid
 		}
 	}
-
-	audience := issuer
-	if opts != nil && opts.TokenEndpoint != "" {
-		audience = opts.TokenEndpoint
+	if clientID == "" {
+		return nil, &WebIdentityConfigurationError{Message: "client id is required for the assertion: set WithClientID or supply resource_client_id in the request auth context"}
 	}
 
-	assertion, err := w.keyManager.CreateClientAssertion(ctx, issuer, audience)
+	// aud is the audience override when set, otherwise the authorization server's token
+	// endpoint. There is no issuer fallback.
+	audience := w.audienceConfig
+	if audience == "" && opts != nil {
+		audience = opts.TokenEndpoint
+	}
+	if audience == "" {
+		return nil, &WebIdentityConfigurationError{Message: "token endpoint is required for the assertion audience"}
+	}
+
+	assertion, err := w.keyManager.CreateClientAssertion(ctx, clientID, audience)
 	if err != nil {
 		return nil, fmt.Errorf("creating client assertion: %w", err)
 	}

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -15,6 +15,17 @@ func (e *AuthProviderConfigurationError) Error() string {
 	return e.Message
 }
 
+// WebIdentityConfigurationError indicates a WebIdentity client assertion could not be
+// prepared because a required value was missing at request time: the client id (iss/sub)
+// or the token endpoint (aud).
+type WebIdentityConfigurationError struct {
+	Message string
+}
+
+func (e *WebIdentityConfigurationError) Error() string {
+	return e.Message
+}
+
 // EKSWorkloadIdentityConfigurationError indicates invalid EKS workload identity configuration
 // detected at construction (e.g. no token file path, or the file is missing or empty). Err
 // carries the underlying cause (e.g. os.ErrNotExist or os.ErrPermission from reading the

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -98,6 +98,15 @@ func NewAuthProvider(opts ...AuthProviderOption) (*AuthProvider, error) {
 		opt(&cfg)
 	}
 
+	// A WebIdentity credential needs a client id for its assertion, and the provider has
+	// no way to supply one at request time (it never sets resource_client_id). Without it
+	// every exchange would fail with a config error, so fail loudly at construction.
+	if wi, ok := cfg.applicationCredential.(*WebIdentityCredential); ok && wi.clientID == "" {
+		return nil, &AuthProviderConfigurationError{
+			Message: "WebIdentity credential requires a client id: pass mcp.WithClientID to NewWebIdentity",
+		}
+	}
+
 	p := &AuthProvider{
 		credential: cfg.applicationCredential,
 		httpClient: cfg.httpClient,

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -30,6 +30,11 @@ const (
 // NewAccessContext creates a new empty AccessContext.
 func NewAccessContext() *AccessContext { return oauth.NewAccessContext() }
 
+// NewAccessContextWithTokens creates an AccessContext pre-seeded with tokens, keyed by resource.
+func NewAccessContextWithTokens(tokens map[string]*oauth.TokenResponse) *AccessContext {
+	return oauth.NewAccessContextWithTokens(tokens)
+}
+
 // AuthProviderOption configures an AuthProvider.
 type AuthProviderOption func(*authProviderConfig)
 

--- a/mcp/webidentity_test.go
+++ b/mcp/webidentity_test.go
@@ -106,6 +106,26 @@ func TestWebIdentity_AudienceConfigOverride(t *testing.T) {
 	}
 }
 
+func TestNewAuthProvider_WebIdentityRequiresClientID(t *testing.T) {
+	// The provider cannot supply resource_client_id at request time, so a WebIdentity
+	// credential without a client id is unusable; NewAuthProvider rejects it at construction.
+	_, err := NewAuthProvider(
+		WithZoneURL("https://zone.example.com"),
+		WithApplicationCredential(NewWebIdentity(WithStorageDir(t.TempDir()))),
+	)
+	var cfgErr *AuthProviderConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want AuthProviderConfigurationError", err)
+	}
+
+	if _, err := NewAuthProvider(
+		WithZoneURL("https://zone.example.com"),
+		WithApplicationCredential(NewWebIdentity(WithClientID("client-a"), WithStorageDir(t.TempDir()))),
+	); err != nil {
+		t.Errorf("with a client id, construction should succeed: %v", err)
+	}
+}
+
 func TestChooseStorageDir(t *testing.T) {
 	base := t.TempDir()
 	def := filepath.Join(base, "server_keys")

--- a/mcp/webidentity_test.go
+++ b/mcp/webidentity_test.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keycardai/credentials-go/oauth"
+)
+
+// assertionClaims decodes (without verifying) the claims of a JWT client assertion.
+func assertionClaims(t *testing.T, jwt string) map[string]any {
+	t.Helper()
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("not a JWT: %q", jwt)
+	}
+	payload, err := oauth.Base64URLDecode(parts[1])
+	if err != nil {
+		t.Fatalf("decoding assertion payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshaling assertion claims: %v", err)
+	}
+	return claims
+}
+
+func TestWebIdentity_AssertionClaims(t *testing.T) {
+	cred := NewWebIdentity(WithClientID("client-a"), WithStorageDir(t.TempDir()))
+
+	req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://api.example.com",
+		&PrepareOptions{TokenEndpoint: "https://zone.example.com/token"})
+	if err != nil {
+		t.Fatalf("PrepareTokenExchangeRequest: %v", err)
+	}
+	if req.ClientAssertionType != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("client_assertion_type: got %q", req.ClientAssertionType)
+	}
+
+	claims := assertionClaims(t, req.ClientAssertion)
+	if claims["iss"] != "client-a" {
+		t.Errorf("iss: got %v, want client-a", claims["iss"])
+	}
+	if claims["sub"] != "client-a" {
+		t.Errorf("sub: got %v, want client-a", claims["sub"])
+	}
+	if claims["aud"] != "https://zone.example.com/token" {
+		t.Errorf("aud: got %v, want the token endpoint", claims["aud"])
+	}
+}
+
+func TestWebIdentity_RequiresClientID(t *testing.T) {
+	cred := NewWebIdentity(WithStorageDir(t.TempDir())) // no client id configured
+
+	_, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "res",
+		&PrepareOptions{TokenEndpoint: "https://zone.example.com/token"})
+
+	var cfgErr *WebIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WebIdentityConfigurationError (no key-id fallback)", err)
+	}
+}
+
+func TestWebIdentity_RequiresTokenEndpoint(t *testing.T) {
+	cred := NewWebIdentity(WithClientID("client-a"), WithStorageDir(t.TempDir()))
+
+	_, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "res",
+		&PrepareOptions{}) // no token endpoint, no audience override
+
+	var cfgErr *WebIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WebIdentityConfigurationError (no issuer fallback)", err)
+	}
+}
+
+func TestWebIdentity_ResourceClientIDOverrides(t *testing.T) {
+	cred := NewWebIdentity(WithClientID("configured"), WithStorageDir(t.TempDir()))
+
+	req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "res", &PrepareOptions{
+		TokenEndpoint: "https://zone.example.com/token",
+		AuthInfo:      map[string]string{"resource_client_id": "from-request"},
+	})
+	if err != nil {
+		t.Fatalf("PrepareTokenExchangeRequest: %v", err)
+	}
+	if claims := assertionClaims(t, req.ClientAssertion); claims["iss"] != "from-request" {
+		t.Errorf("iss: got %v, want from-request (resource_client_id overrides)", claims["iss"])
+	}
+}
+
+func TestWebIdentity_AudienceConfigOverride(t *testing.T) {
+	cred := NewWebIdentity(WithClientID("client-a"), WithAudienceConfig("https://custom.audience"), WithStorageDir(t.TempDir()))
+
+	req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "res",
+		&PrepareOptions{TokenEndpoint: "https://zone.example.com/token"})
+	if err != nil {
+		t.Fatalf("PrepareTokenExchangeRequest: %v", err)
+	}
+	if claims := assertionClaims(t, req.ClientAssertion); claims["aud"] != "https://custom.audience" {
+		t.Errorf("aud: got %v, want the audience override", claims["aud"])
+	}
+}
+
+func TestChooseStorageDir(t *testing.T) {
+	base := t.TempDir()
+	def := filepath.Join(base, "server_keys")
+	legacy := filepath.Join(base, "mcp_keys")
+
+	if got := chooseStorageDir(def, legacy); got != def {
+		t.Errorf("neither exists: got %q, want default %q", got, def)
+	}
+
+	if err := os.Mkdir(legacy, 0o755); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if got := chooseStorageDir(def, legacy); got != legacy {
+		t.Errorf("legacy only: got %q, want legacy %q", got, legacy)
+	}
+
+	if err := os.Mkdir(def, 0o755); err != nil {
+		t.Fatalf("mkdir default: %v", err)
+	}
+	if got := chooseStorageDir(def, legacy); got != def {
+		t.Errorf("both exist: got %q, want default %q", got, def)
+	}
+}

--- a/oauth/access_context.go
+++ b/oauth/access_context.go
@@ -49,6 +49,14 @@ func NewAccessContext() *AccessContext {
 	}
 }
 
+// NewAccessContextWithTokens creates an AccessContext pre-seeded with tokens, keyed by
+// resource. It mirrors the seed-token constructor in the Python and TypeScript SDKs.
+func NewAccessContextWithTokens(tokens map[string]*TokenResponse) *AccessContext {
+	ac := NewAccessContext()
+	ac.SetBulkTokens(tokens)
+	return ac
+}
+
 // SetToken sets a successful token for a resource (clears any error for that resource).
 func (ac *AccessContext) SetToken(resource string, token *TokenResponse) {
 	ac.tokens[resource] = token

--- a/oauth/access_context_test.go
+++ b/oauth/access_context_test.go
@@ -2,6 +2,22 @@ package oauth
 
 import "testing"
 
+func TestNewAccessContextWithTokens(t *testing.T) {
+	ac := NewAccessContextWithTokens(map[string]*TokenResponse{
+		"res-a": {AccessToken: "ta"},
+	})
+	if ac.Status() != StatusSuccess {
+		t.Errorf("status: got %q, want success", ac.Status())
+	}
+	tok, err := ac.Access("res-a")
+	if err != nil {
+		t.Fatalf("access: %v", err)
+	}
+	if tok.AccessToken != "ta" {
+		t.Errorf("token: got %q, want ta", tok.AccessToken)
+	}
+}
+
 func TestAccessContext_MergeTokensAndErrors(t *testing.T) {
 	a := NewAccessContext()
 	a.SetToken("res-a", &TokenResponse{AccessToken: "ta"})


### PR DESCRIPTION
## What

Closes the last two ECO-94 checklist items.

### WebIdentity tightening (aligns the `private_key_jwt` assertion to the spec)
- **`WithClientID`** — the assertion's `iss`/`sub` are the registered OAuth client id, with a request-time `resource_client_id` (from the exchange auth context) overriding it. **The key-id fallback for `iss` is dropped**, and the `iss` fallback for `aud` is dropped: `PrepareTokenExchangeRequest` now returns a `WebIdentityConfigurationError` when the client id or token endpoint is missing (RFC 7523).
- **Storage default → `./server_keys`**, falling back to the legacy `./mcp_keys` when it exists — matching Python/TS.
- **`WithAudienceConfig`** — override the assertion audience (single-audience form; the per-zone map is part of the multi-zone effort, per the spec).

### AccessContext
- **`NewAccessContextWithTokens`** — the seed-token constructor present in Python/TS (re-exported from `oauth`, where `AccessContext` lives).

## Breaking change

A WebIdentity credential now **requires a client id** (`WithClientID` or a request-time `resource_client_id`) and a **token endpoint**; it no longer signs with the local key id as `iss`. Default key storage is `./server_keys` (legacy `./mcp_keys` honored if present).

## Resolving the spec contradiction

The WebIdentity spec's construction table says there's no `client_id` option (resolved at request time), but its Divergences row says TS aligned by adding `WebIdentity({ clientId })`. Recon of the actual code confirmed the two reference SDKs genuinely differ — TS uses an optional construction-time `clientId` (its provider passes no auth context); Python requires a request-time `resource_client_id` (its provider supplies it from the verified request). Go's provider supplies neither and has no client id to source, so this follows the **TS model** (optional `WithClientID` + request-time override), which satisfies the spec contract (`iss=sub=client_id`, `aud=token_endpoint`, no key-id fallback) without new provider plumbing.

## Verify

- `go build ./... ./examples/...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./...`: new `mcp/webidentity_test.go` decodes the signed assertion and checks `iss`/`sub`=client id, `aud`=token endpoint, the `resource_client_id` override, the audience override, both missing-value errors, and the `./server_keys`/`./mcp_keys` storage resolution; `oauth` covers `NewAccessContextWithTokens`.

Linear: ECO-94. With this merged, all ten ECO-94 items are shipped → ECO-94 Done.