### PR TITLE
fix: allow for non-actor impersonation

### DIFF
--- a/examples/impersonation/main.go
+++ b/examples/impersonation/main.go
@@ -6,11 +6,10 @@
 // requested resource. Impersonation is forbidden by default and must be
 // explicitly permitted by server-side Keycard policy.
 //
-// It performs an RFC 8693 token exchange where the actor token is minted from
-// the client's own credentials (a client_credentials grant) and the subject
-// token is an unsigned substitute-user assertion carrying the target user id.
-// The issued token's "sub" is the target user; its "act" chain identifies this
-// service for audit.
+// It performs an RFC 8693 token exchange authenticated with the client's own
+// credentials, where the subject token is an unsigned substitute-user
+// assertion carrying the target user id. The issued token's "sub" is the
+// target user; the server records this service in its "act" chain for audit.
 //
 // Configuration (environment variables):
 //

--- a/oauth/impersonate.go
+++ b/oauth/impersonate.go
@@ -12,17 +12,7 @@ import (
 // server that the subject_token is an unsigned substitute-user assertion.
 const SubstituteUserTokenType = "urn:keycard:params:oauth:token-type:substitute-user"
 
-// substituteUserActorTokenType is the IANA URN used as actor_token_type when
-// the actor token is an OAuth 2.0 access token (RFC 8693 §3).
-const substituteUserActorTokenType = "urn:ietf:params:oauth:token-type:access_token"
-
 // ImpersonateRequest contains the inputs for an impersonation token exchange.
-//
-// The zero value of each optional field selects the plain substitute-user
-// exchange: no actor token, authenticated by the credentials configured on
-// the TokenExchangeClient. That is the shape current Keycard zones accept —
-// zones without RFC 8693 actor-token support reject every actor_token_type
-// with invalid_request ("Unsupported actor token type").
 type ImpersonateRequest struct {
 	// UserIdentifier is the target user. Becomes "sub" in the issued token. Required.
 	UserIdentifier string
@@ -30,16 +20,10 @@ type ImpersonateRequest struct {
 	Resource string
 	// Scopes are the scopes requested for the issued token. Optional.
 	Scopes []string
-	// ActorResource, when set, attaches an RFC 8693 actor_token to the
-	// exchange: an access token minted via a client_credentials grant
-	// audienced to this resource (typically the calling service's own
-	// resource — a resource-less mint is denied by zone policy). Leave zero
-	// against zones without actor-token support.
-	ActorResource string
 	// ClientAssertion, with ClientAssertionType, authenticates the exchange
-	// (and the actor mint, when ActorResource is set) via a JWT bearer
-	// assertion — e.g. a workload-identity OIDC token — instead of the
-	// client's configured basic-auth secret. Zero values use the secret.
+	// via a JWT bearer assertion — e.g. a workload-identity OIDC token —
+	// instead of the client's configured basic-auth secret. Zero values use
+	// the secret.
 	ClientAssertion     string
 	ClientAssertionType string
 }
@@ -47,11 +31,11 @@ type ImpersonateRequest struct {
 // Impersonate exchanges the client's application credential for a token that
 // acts on behalf of req.UserIdentifier.
 //
-// It performs an RFC 8693 token exchange where:
-//   - subject_token is an unsigned substitute-user JWT carrying the user id
-//   - subject_token_type is SubstituteUserTokenType
-//   - actor_token is attached only when req.ActorResource is set, minted via
-//     a client_credentials grant audienced to that resource
+// It performs an RFC 8693 token exchange where subject_token is an unsigned
+// substitute-user JWT carrying the user id and subject_token_type is
+// SubstituteUserTokenType. The authorization server derives the acting party
+// from the authenticated client and records it in the issued token's "act"
+// claim chain; no actor_token is sent.
 //
 // Impersonation is a privileged operation gated by server-side policy and is
 // forbidden by default. The authorization server returns "unauthorized_client"
@@ -65,29 +49,14 @@ func (c *TokenExchangeClient) Impersonate(ctx context.Context, req ImpersonateRe
 		return nil, errors.New("oauth: ImpersonateRequest.Resource is required")
 	}
 
-	exchange := TokenExchangeRequest{
+	return c.ExchangeToken(ctx, TokenExchangeRequest{
 		SubjectToken:        buildSubstituteUserToken(req.UserIdentifier),
 		SubjectTokenType:    SubstituteUserTokenType,
 		Resource:            req.Resource,
 		Scope:               strings.Join(req.Scopes, " "),
 		ClientAssertion:     req.ClientAssertion,
 		ClientAssertionType: req.ClientAssertionType,
-	}
-
-	if req.ActorResource != "" {
-		actor, err := c.clientCredentialsClient().RequestToken(ctx, ClientCredentialsRequest{
-			Resource:            req.ActorResource,
-			ClientAssertion:     req.ClientAssertion,
-			ClientAssertionType: req.ClientAssertionType,
-		})
-		if err != nil {
-			return nil, err
-		}
-		exchange.ActorToken = actor.AccessToken
-		exchange.ActorTokenType = substituteUserActorTokenType
-	}
-
-	return c.ExchangeToken(ctx, exchange)
+	})
 }
 
 // buildSubstituteUserToken constructs the unsigned JWT used as subject_token

--- a/oauth/impersonate.go
+++ b/oauth/impersonate.go
@@ -18,10 +18,11 @@ const substituteUserActorTokenType = "urn:ietf:params:oauth:token-type:access_to
 
 // ImpersonateRequest contains the inputs for an impersonation token exchange.
 //
-// The calling service's application credential supplies the actor identity;
-// callers do not pass it explicitly. The configured TokenExchangeClient
-// credential is used both to mint the actor token (via a client_credentials
-// grant) and to authenticate the exchange request.
+// The zero value of each optional field selects the plain substitute-user
+// exchange: no actor token, authenticated by the credentials configured on
+// the TokenExchangeClient. That is the shape current Keycard zones accept —
+// zones without RFC 8693 actor-token support reject every actor_token_type
+// with invalid_request ("Unsupported actor token type").
 type ImpersonateRequest struct {
 	// UserIdentifier is the target user. Becomes "sub" in the issued token. Required.
 	UserIdentifier string
@@ -29,20 +30,33 @@ type ImpersonateRequest struct {
 	Resource string
 	// Scopes are the scopes requested for the issued token. Optional.
 	Scopes []string
+	// ActorResource, when set, attaches an RFC 8693 actor_token to the
+	// exchange: an access token minted via a client_credentials grant
+	// audienced to this resource (typically the calling service's own
+	// resource — a resource-less mint is denied by zone policy). Leave zero
+	// against zones without actor-token support.
+	ActorResource string
+	// ClientAssertion, with ClientAssertionType, authenticates the exchange
+	// (and the actor mint, when ActorResource is set) via a JWT bearer
+	// assertion — e.g. a workload-identity OIDC token — instead of the
+	// client's configured basic-auth secret. Zero values use the secret.
+	ClientAssertion     string
+	ClientAssertionType string
 }
 
 // Impersonate exchanges the client's application credential for a token that
 // acts on behalf of req.UserIdentifier.
 //
 // It performs an RFC 8693 token exchange where:
-//   - actor_token is minted via a client_credentials grant using the
-//     credentials configured on this TokenExchangeClient
 //   - subject_token is an unsigned substitute-user JWT carrying the user id
 //   - subject_token_type is SubstituteUserTokenType
+//   - actor_token is attached only when req.ActorResource is set, minted via
+//     a client_credentials grant audienced to that resource
 //
 // Impersonation is a privileged operation gated by server-side policy and is
 // forbidden by default. The authorization server returns "unauthorized_client"
-// when the calling client is not permitted to impersonate.
+// when the calling client is not permitted to impersonate and "invalid_grant"
+// when the user is unknown or not impersonatable.
 func (c *TokenExchangeClient) Impersonate(ctx context.Context, req ImpersonateRequest) (*TokenResponse, error) {
 	if req.UserIdentifier == "" {
 		return nil, errors.New("oauth: ImpersonateRequest.UserIdentifier is required")
@@ -51,19 +65,29 @@ func (c *TokenExchangeClient) Impersonate(ctx context.Context, req ImpersonateRe
 		return nil, errors.New("oauth: ImpersonateRequest.Resource is required")
 	}
 
-	actor, err := c.clientCredentialsClient().RequestToken(ctx, ClientCredentialsRequest{})
-	if err != nil {
-		return nil, err
+	exchange := TokenExchangeRequest{
+		SubjectToken:        buildSubstituteUserToken(req.UserIdentifier),
+		SubjectTokenType:    SubstituteUserTokenType,
+		Resource:            req.Resource,
+		Scope:               strings.Join(req.Scopes, " "),
+		ClientAssertion:     req.ClientAssertion,
+		ClientAssertionType: req.ClientAssertionType,
 	}
 
-	return c.ExchangeToken(ctx, TokenExchangeRequest{
-		SubjectToken:     buildSubstituteUserToken(req.UserIdentifier),
-		SubjectTokenType: SubstituteUserTokenType,
-		ActorToken:       actor.AccessToken,
-		ActorTokenType:   substituteUserActorTokenType,
-		Resource:         req.Resource,
-		Scope:            strings.Join(req.Scopes, " "),
-	})
+	if req.ActorResource != "" {
+		actor, err := c.clientCredentialsClient().RequestToken(ctx, ClientCredentialsRequest{
+			Resource:            req.ActorResource,
+			ClientAssertion:     req.ClientAssertion,
+			ClientAssertionType: req.ClientAssertionType,
+		})
+		if err != nil {
+			return nil, err
+		}
+		exchange.ActorToken = actor.AccessToken
+		exchange.ActorTokenType = substituteUserActorTokenType
+	}
+
+	return c.ExchangeToken(ctx, exchange)
 }
 
 // buildSubstituteUserToken constructs the unsigned JWT used as subject_token

--- a/oauth/impersonate_test.go
+++ b/oauth/impersonate_test.go
@@ -84,9 +84,11 @@ func oauthErrorResponder(status int, code string) http.HandlerFunc {
 	}
 }
 
-// Spec table row 1: valid user, valid resource → token returned, substitute-user URN sent.
+// Spec table row 1: valid user, valid resource → token returned, substitute-user URN
+// sent, and by default no actor token — zones without RFC 8693 actor-token support
+// reject any actor_token_type, so the zero value must produce the plain exchange.
 func TestImpersonate_FullCall(t *testing.T) {
-	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+	f := newImpersonateFixture(t, exchangeOKResponder())
 
 	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
 	resp, err := client.Impersonate(context.Background(), ImpersonateRequest{
@@ -101,26 +103,22 @@ func TestImpersonate_FullCall(t *testing.T) {
 		t.Errorf("access_token: got %q, want issued-token", resp.AccessToken)
 	}
 
-	if len(f.calls) != 2 {
-		t.Fatalf("token endpoint hit count: got %d, want 2", len(f.calls))
+	if len(f.calls) != 1 {
+		t.Fatalf("token endpoint hit count: got %d, want 1 (exchange only)", len(f.calls))
 	}
 
-	cc, exchange := f.calls[0], f.calls[1]
-	if cc.Get("grant_type") != "client_credentials" {
-		t.Errorf("client_credentials grant_type: got %q", cc.Get("grant_type"))
-	}
-
+	exchange := f.calls[0]
 	if got := exchange.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:token-exchange" {
 		t.Errorf("exchange grant_type: got %q", got)
 	}
 	if got := exchange.Get("subject_token_type"); got != SubstituteUserTokenType {
 		t.Errorf("subject_token_type: got %q, want %q", got, SubstituteUserTokenType)
 	}
-	if got := exchange.Get("actor_token"); got != "actor-access-token" {
-		t.Errorf("actor_token: got %q", got)
+	if exchange.Has("actor_token") {
+		t.Errorf("actor_token: got %q, want absent", exchange.Get("actor_token"))
 	}
-	if got := exchange.Get("actor_token_type"); got != substituteUserActorTokenType {
-		t.Errorf("actor_token_type: got %q", got)
+	if exchange.Has("actor_token_type") {
+		t.Errorf("actor_token_type: got %q, want absent", exchange.Get("actor_token_type"))
 	}
 	if got := exchange.Get("resource"); got != "https://graph.microsoft.com" {
 		t.Errorf("resource: got %q", got)
@@ -135,9 +133,58 @@ func TestImpersonate_FullCall(t *testing.T) {
 	}
 }
 
+// ActorResource set → an actor token is minted via client_credentials audienced to
+// it and attached to the exchange; ClientAssertion rides on both calls.
+func TestImpersonate_WithActorResource(t *testing.T) {
+	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+
+	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	resp, err := client.Impersonate(context.Background(), ImpersonateRequest{
+		UserIdentifier:      "alice@example.com",
+		Resource:            "https://graph.microsoft.com",
+		ActorResource:       "urn:example:agent:self",
+		ClientAssertion:     "assertion.jwt.value",
+		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+	})
+	if err != nil {
+		t.Fatalf("Impersonate: %v", err)
+	}
+	if resp.AccessToken != "issued-token" {
+		t.Errorf("access_token: got %q, want issued-token", resp.AccessToken)
+	}
+
+	if len(f.calls) != 2 {
+		t.Fatalf("token endpoint hit count: got %d, want 2 (actor mint + exchange)", len(f.calls))
+	}
+
+	cc, exchange := f.calls[0], f.calls[1]
+	if got := cc.Get("grant_type"); got != "client_credentials" {
+		t.Errorf("actor mint grant_type: got %q", got)
+	}
+	if got := cc.Get("resource"); got != "urn:example:agent:self" {
+		t.Errorf("actor mint resource: got %q, want urn:example:agent:self", got)
+	}
+	if got := cc.Get("client_assertion"); got != "assertion.jwt.value" {
+		t.Errorf("actor mint client_assertion: got %q", got)
+	}
+
+	if got := exchange.Get("actor_token"); got != "actor-access-token" {
+		t.Errorf("actor_token: got %q", got)
+	}
+	if got := exchange.Get("actor_token_type"); got != substituteUserActorTokenType {
+		t.Errorf("actor_token_type: got %q", got)
+	}
+	if got := exchange.Get("client_assertion"); got != "assertion.jwt.value" {
+		t.Errorf("exchange client_assertion: got %q", got)
+	}
+	if got := exchange.Get("client_assertion_type"); got != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("exchange client_assertion_type: got %q", got)
+	}
+}
+
 // Spec table row 2: unknown user_identifier → invalid_grant.
 func TestImpersonate_UnknownUserIdentifier(t *testing.T) {
-	f := newImpersonateFixture(t, ccOKResponder(), oauthErrorResponder(http.StatusBadRequest, "invalid_grant"))
+	f := newImpersonateFixture(t, oauthErrorResponder(http.StatusBadRequest, "invalid_grant"))
 
 	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
 	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
@@ -155,7 +202,7 @@ func TestImpersonate_UnknownUserIdentifier(t *testing.T) {
 
 // Spec table row 3: client lacks impersonation permission → unauthorized_client.
 func TestImpersonate_UnauthorizedClient(t *testing.T) {
-	f := newImpersonateFixture(t, ccOKResponder(), oauthErrorResponder(http.StatusBadRequest, "unauthorized_client"))
+	f := newImpersonateFixture(t, oauthErrorResponder(http.StatusBadRequest, "unauthorized_client"))
 
 	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
 	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
@@ -188,7 +235,7 @@ func TestImpersonate_ResourceRequiredLocally(t *testing.T) {
 
 // Spec table row 5: scopes omitted → exchange call omits scope param.
 func TestImpersonate_ScopesOmitted(t *testing.T) {
-	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+	f := newImpersonateFixture(t, exchangeOKResponder())
 
 	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
 	_, err := client.Impersonate(context.Background(), ImpersonateRequest{
@@ -198,7 +245,7 @@ func TestImpersonate_ScopesOmitted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Impersonate: %v", err)
 	}
-	exchange := f.calls[1]
+	exchange := f.calls[0]
 	if exchange.Has("scope") {
 		t.Errorf("scope should be omitted, got %q", exchange.Get("scope"))
 	}

--- a/oauth/impersonate_test.go
+++ b/oauth/impersonate_test.go
@@ -53,17 +53,6 @@ func newImpersonateFixture(t *testing.T, responders ...http.HandlerFunc) *impers
 	return f
 }
 
-func ccOKResponder() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "actor-access-token",
-			"token_type":   "Bearer",
-			"expires_in":   3600,
-		})
-	}
-}
-
 func exchangeOKResponder() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -85,8 +74,8 @@ func oauthErrorResponder(status int, code string) http.HandlerFunc {
 }
 
 // Spec table row 1: valid user, valid resource → token returned, substitute-user URN
-// sent, and by default no actor token — zones without RFC 8693 actor-token support
-// reject any actor_token_type, so the zero value must produce the plain exchange.
+// sent, and no actor token — the server derives the acting party from the
+// authenticated client.
 func TestImpersonate_FullCall(t *testing.T) {
 	f := newImpersonateFixture(t, exchangeOKResponder())
 
@@ -133,16 +122,15 @@ func TestImpersonate_FullCall(t *testing.T) {
 	}
 }
 
-// ActorResource set → an actor token is minted via client_credentials audienced to
-// it and attached to the exchange; ClientAssertion rides on both calls.
-func TestImpersonate_WithActorResource(t *testing.T) {
-	f := newImpersonateFixture(t, ccOKResponder(), exchangeOKResponder())
+// ClientAssertion set → the assertion authenticates the exchange in the form
+// body; still a single token call with no actor fields.
+func TestImpersonate_WithClientAssertion(t *testing.T) {
+	f := newImpersonateFixture(t, exchangeOKResponder())
 
-	client := NewTokenExchangeClient(f.server.URL, WithClientCredentials("app", "secret"))
+	client := NewTokenExchangeClient(f.server.URL)
 	resp, err := client.Impersonate(context.Background(), ImpersonateRequest{
 		UserIdentifier:      "alice@example.com",
 		Resource:            "https://graph.microsoft.com",
-		ActorResource:       "urn:example:agent:self",
 		ClientAssertion:     "assertion.jwt.value",
 		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
 	})
@@ -153,32 +141,20 @@ func TestImpersonate_WithActorResource(t *testing.T) {
 		t.Errorf("access_token: got %q, want issued-token", resp.AccessToken)
 	}
 
-	if len(f.calls) != 2 {
-		t.Fatalf("token endpoint hit count: got %d, want 2 (actor mint + exchange)", len(f.calls))
+	if len(f.calls) != 1 {
+		t.Fatalf("token endpoint hit count: got %d, want 1 (exchange only)", len(f.calls))
 	}
 
-	cc, exchange := f.calls[0], f.calls[1]
-	if got := cc.Get("grant_type"); got != "client_credentials" {
-		t.Errorf("actor mint grant_type: got %q", got)
-	}
-	if got := cc.Get("resource"); got != "urn:example:agent:self" {
-		t.Errorf("actor mint resource: got %q, want urn:example:agent:self", got)
-	}
-	if got := cc.Get("client_assertion"); got != "assertion.jwt.value" {
-		t.Errorf("actor mint client_assertion: got %q", got)
-	}
-
-	if got := exchange.Get("actor_token"); got != "actor-access-token" {
-		t.Errorf("actor_token: got %q", got)
-	}
-	if got := exchange.Get("actor_token_type"); got != substituteUserActorTokenType {
-		t.Errorf("actor_token_type: got %q", got)
-	}
+	exchange := f.calls[0]
 	if got := exchange.Get("client_assertion"); got != "assertion.jwt.value" {
-		t.Errorf("exchange client_assertion: got %q", got)
+		t.Errorf("client_assertion: got %q", got)
 	}
 	if got := exchange.Get("client_assertion_type"); got != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
-		t.Errorf("exchange client_assertion_type: got %q", got)
+		t.Errorf("client_assertion_type: got %q", got)
+	}
+	if exchange.Has("actor_token") || exchange.Has("actor_token_type") {
+		t.Errorf("actor fields must be absent, got actor_token=%q actor_token_type=%q",
+			exchange.Get("actor_token"), exchange.Get("actor_token_type"))
 	}
 }
 

--- a/oauth/token_exchange.go
+++ b/oauth/token_exchange.go
@@ -70,9 +70,6 @@ type TokenExchangeClient struct {
 	once          sync.Once
 	tokenEndpoint string
 	discoverErr   error
-
-	ccOnce sync.Once
-	cc     *ClientCredentialsClient
 }
 
 // NewTokenExchangeClient creates a new TokenExchangeClient for the given issuer.
@@ -129,20 +126,6 @@ func (c *TokenExchangeClient) ExchangeToken(ctx context.Context, req TokenExchan
 	}
 
 	return deserializeTokenResponse(resp)
-}
-
-// clientCredentialsClient lazily builds a ClientCredentialsClient that shares this
-// client's issuer, credentials, and HTTP client. It is used to mint the actor token
-// for an impersonation exchange, reusing the client-credentials grant rather than
-// reimplementing it. The instance is cached so it discovers its token endpoint once.
-func (c *TokenExchangeClient) clientCredentialsClient() *ClientCredentialsClient {
-	c.ccOnce.Do(func() {
-		c.cc = NewClientCredentialsClient(c.issuerURL,
-			WithCCBasicAuth(c.cfg.clientID, c.cfg.clientSecret),
-			WithCCHTTPClient(c.cfg.httpClient),
-		)
-	})
-	return c.cc
 }
 
 func (c *TokenExchangeClient) getTokenEndpoint(ctx context.Context) (string, error) {


### PR DESCRIPTION
Removes unsupported `actor_token` and adds client assertion for token exchange.