### PR TITLE
Rename `credentials-go` to `sdk-go`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Go SDK for [Keycard](https://keycard.cloud) — OAuth 2.0 and MCP authentication
 ## Installation
 
 ```bash
-go get github.com/keycardai/credentials-go
+go get github.com/keycardai/go-sdk
 ```
 
 Import the sub-package you need:
 
 ```go
-import "github.com/keycardai/credentials-go/oauth"  // Pure OAuth 2.0 primitives
-import "github.com/keycardai/credentials-go/mcp"    // MCP-specific OAuth integration
-import "github.com/keycardai/credentials-go/a2a"    // Agent-to-agent delegation
+import "github.com/keycardai/go-sdk/oauth"  // Pure OAuth 2.0 primitives
+import "github.com/keycardai/go-sdk/mcp"    // MCP-specific OAuth integration
+import "github.com/keycardai/go-sdk/a2a"    // Agent-to-agent delegation
 ```
 
 ## Packages
@@ -134,11 +134,11 @@ authProvider, _ := mcp.NewAuthProvider(
 
 ## Credential Types
 
-| Type | Auth Method | Use Case |
-|------|-------------|----------|
-| `ClientSecret` | HTTP Basic Auth | Simple deployments with client_id/secret |
-| `WebIdentity` | `private_key_jwt` (RFC 7523) | Zero-secret deployments, auto-generates RSA keys |
-| `EKSWorkloadIdentity` | Pod identity token | AWS EKS workloads |
+| Type                  | Auth Method                  | Use Case                                         |
+| --------------------- | ---------------------------- | ------------------------------------------------ |
+| `ClientSecret`        | HTTP Basic Auth              | Simple deployments with client_id/secret         |
+| `WebIdentity`         | `private_key_jwt` (RFC 7523) | Zero-secret deployments, auto-generates RSA keys |
+| `EKSWorkloadIdentity` | Pod identity token           | AWS EKS workloads                                |
 
 ## Error Handling
 
@@ -181,5 +181,5 @@ git push origin v0.1.0
 [pkg.go.dev](https://pkg.go.dev) indexes automatically. To trigger manually:
 
 ```bash
-GOPROXY=proxy.golang.org go list -m github.com/keycardai/credentials-go@v0.1.0
+GOPROXY=proxy.golang.org go list -m github.com/keycardai/go-sdk@v0.1.0
 ```

--- a/a2a/client.go
+++ b/a2a/client.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 const (

--- a/a2a/client_test.go
+++ b/a2a/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // fakeZone is a fake Keycard authorization server: it advertises a token endpoint and

--- a/a2a/example_test.go
+++ b/a2a/example_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/keycardai/credentials-go/a2a"
+	"github.com/keycardai/go-sdk/a2a"
 )
 
 // ExampleDelegationClient_Invoke shows a calling agent delegating a task to a target

--- a/doc.go
+++ b/doc.go
@@ -5,14 +5,14 @@
 //
 // The SDK is organized into two sub-packages:
 //
-//   - [github.com/keycardai/credentials-go/oauth] — Pure OAuth 2.0 primitives: JWT signing/verification,
+//   - [github.com/keycardai/go-sdk/oauth] — Pure OAuth 2.0 primitives: JWT signing/verification,
 //     JWKS key discovery with caching, RFC 8693 token exchange, and OAuth server metadata discovery.
 //
-//   - [github.com/keycardai/credentials-go/mcp] — MCP-specific OAuth integration: bearer auth middleware,
+//   - [github.com/keycardai/go-sdk/mcp] — MCP-specific OAuth integration: bearer auth middleware,
 //     token exchange orchestration (AuthProvider), application credentials, and well-known metadata endpoints.
 //
 // Import the sub-package you need:
 //
-//	import "github.com/keycardai/credentials-go/oauth"  // OAuth primitives only
-//	import "github.com/keycardai/credentials-go/mcp"    // MCP integration (includes oauth)
+//	import "github.com/keycardai/go-sdk/oauth"  // OAuth primitives only
+//	import "github.com/keycardai/go-sdk/mcp"    // MCP integration (includes oauth)
 package keycardai

--- a/examples/a2a/main.go
+++ b/examples/a2a/main.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/keycardai/credentials-go/a2a"
+	"github.com/keycardai/go-sdk/a2a"
 )
 
 func main() {

--- a/examples/authorization-code-pkce/main.go
+++ b/examples/authorization-code-pkce/main.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 func main() {

--- a/examples/delegated-access/main.go
+++ b/examples/delegated-access/main.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/keycardai/credentials-go/mcp"
+	"github.com/keycardai/go-sdk/mcp"
 )
 
 func main() {

--- a/examples/discovery/main.go
+++ b/examples/discovery/main.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 func main() {

--- a/examples/dynamic-client-registration/main.go
+++ b/examples/dynamic-client-registration/main.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	resp, err := oauth.RegisterClient(ctx, zoneURL, oauth.RegistrationRequest{
-		ClientName:              "credentials-go example",
+		ClientName:              "go-sdk example",
 		RedirectURIs:            []string{"http://127.0.0.1:8765/callback"},
 		GrantTypes:              []string{"authorization_code"},
 		TokenEndpointAuthMethod: "none",

--- a/examples/hello-world-server/main.go
+++ b/examples/hello-world-server/main.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/keycardai/credentials-go/mcp"
+	"github.com/keycardai/go-sdk/mcp"
 )
 
 func main() {

--- a/examples/impersonation/main.go
+++ b/examples/impersonation/main.go
@@ -42,7 +42,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 func main() {

--- a/examples/multi-zone/main.go
+++ b/examples/multi-zone/main.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/keycardai/credentials-go/mcp"
+	"github.com/keycardai/go-sdk/mcp"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/keycardai/credentials-go
+module github.com/keycardai/go-sdk
 
 go 1.22
 

--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // ClientAuth holds client_id and client_secret for HTTP basic auth.

--- a/mcp/doc.go
+++ b/mcp/doc.go
@@ -1,6 +1,6 @@
 // Package mcp provides MCP-specific OAuth integration for the Keycard SDK.
 //
-// This package builds on [github.com/keycardai/credentials-go/oauth] to provide:
+// This package builds on [github.com/keycardai/go-sdk/oauth] to provide:
 //
 //   - Bearer auth middleware for protecting HTTP endpoints ([RequireBearerAuth])
 //   - Token exchange orchestration for delegated access ([AuthProvider], [AccessContext])

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -1,6 +1,6 @@
 package mcp
 
-import "github.com/keycardai/credentials-go/oauth"
+import "github.com/keycardai/go-sdk/oauth"
 
 // ResourceAccessError is re-exported from the oauth package (where it now lives alongside
 // AccessContext) for backward compatibility.

--- a/mcp/grant_test.go
+++ b/mcp/grant_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // grantTokenServer is a fake zone that serves discovery and a /token endpoint, recording

--- a/mcp/middleware.go
+++ b/mcp/middleware.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 type contextKey string

--- a/mcp/middleware_test.go
+++ b/mcp/middleware_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 type mockTokenVerifier struct {

--- a/mcp/middleware_verifier_test.go
+++ b/mcp/middleware_verifier_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // These tests drive real signed JWTs through RequireBearerAuth with a hardened

--- a/mcp/multizone_test.go
+++ b/mcp/multizone_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // mustMultiZone builds a multi-zone client-secret credential and fails the test if

--- a/mcp/private_key.go
+++ b/mcp/private_key.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // PrivateKeyStorage persists RSA key pairs for WebIdentity.

--- a/mcp/provider.go
+++ b/mcp/provider.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // AccessContext, its status/error types, and ResourceAccessError now live in the oauth

--- a/mcp/provider_test.go
+++ b/mcp/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 func TestAccessContext_SetAndAccess(t *testing.T) {

--- a/mcp/signer.go
+++ b/mcp/signer.go
@@ -3,7 +3,7 @@ package mcp
 import (
 	"context"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // JSONWebTokenSigner signs JWTs for MCP client authentication.

--- a/mcp/verifier.go
+++ b/mcp/verifier.go
@@ -3,7 +3,7 @@ package mcp
 import (
 	"context"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // AuthInfo contains information about an authenticated request.

--- a/mcp/webidentity_test.go
+++ b/mcp/webidentity_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // assertionClaims decodes (without verifying) the claims of a JWT client assertion.

--- a/oauth/example_test.go
+++ b/oauth/example_test.go
@@ -3,7 +3,7 @@ package oauth_test
 import (
 	"fmt"
 
-	"github.com/keycardai/credentials-go/oauth"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 // ExampleGenerateCodeChallenge derives an S256 PKCE challenge from a verifier

--- a/scripts/bump.py
+++ b/scripts/bump.py
@@ -133,7 +133,7 @@ def push_changes_with_retry(max_attempts: int = 3) -> bool:
 
 
 def main():
-    print("Starting version bump for credentials-go...")
+    print("Starting version bump for go-sdk...")
 
     configure_git()
 


### PR DESCRIPTION
Replaces all instances of "credentials-go" with "go-sdk", now that the repo is changed.