### PR TITLE
feat(mcp): WorkloadIdentity credential with pluggable identity token sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ authProvider, _ := mcp.NewAuthProvider(
 | `WebIdentity`      | `private_key_jwt` (RFC 7523)     | Zero-secret deployments, auto-generates RSA keys         |
 | `WorkloadIdentity` | Platform OIDC token (jwt-bearer) | EKS, AKS, GKE, Cloud Run, Fly Machines, custom sources   |
 
-`WorkloadIdentity` takes a pluggable token source: `FileTokenSource` (projected token files: EKS, AKS, any Kubernetes projected service-account token), `GCPMetadataTokenSource` (GKE, GCE, Cloud Run), `FlyTokenSource` (Fly Machines), or any `SubjectTokenFunc`:
+`WorkloadIdentity` takes a pluggable token source: `FileTokenSource` (projected token files: EKS, AKS, any Kubernetes projected service-account token), `GCPMetadataTokenSource` (GKE, GCE, Cloud Run), `FlyTokenSource` (Fly Machines), or any `IdentityTokenFunc`:
 
 When the zone-side application credential is resolved by ID (a token-federation credential), pass that ID with `WithWorkloadClientID`; it is sent as the `client_id` form parameter alongside the assertion.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ authProvider, _ := mcp.NewAuthProvider(
 
 `WorkloadIdentity` takes a pluggable token source: `FileTokenSource` (projected token files: EKS, AKS, any Kubernetes projected service-account token), `GCPMetadataTokenSource` (GKE, GCE, Cloud Run), `FlyTokenSource` (Fly Machines), or any `SubjectTokenFunc`:
 
+When the zone-side application credential is resolved by ID (a token-federation credential), pass that ID with `WithWorkloadClientID`; it is sent as the `client_id` form parameter alongside the assertion.
+
 ```go
 source, _ := mcp.NewFileTokenSource() // discovers the projected token file from env
 credential, _ := mcp.NewWorkloadIdentity(source)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Builds on `oauth` to provide server-side and client-side MCP authentication.
 
 - **Bearer auth middleware** — `RequireBearerAuth` (standard `net/http` middleware), audience-bound via `oauth.WithAudiences`
 - **Token exchange orchestration** — `AuthProvider`, `AccessContext`; the `Grant` decorator with `WithUserIdentifier` (impersonation) and `WithRequestScopes`
-- **Application credentials** — `ClientSecret`, `WebIdentity` (RFC 7523), `EKSWorkloadIdentity`; multi-zone via `NewMultiZoneClientSecret`
+- **Application credentials** — `ClientSecret`, `WebIdentity` (RFC 7523), `WorkloadIdentity` (platform OIDC tokens via pluggable sources); multi-zone via `NewMultiZoneClientSecret`
 - **Metadata endpoints** — `AuthMetadataHandler` (`.well-known` endpoints, including `WithPublicJWKS`)
 
 ### `a2a` — Agent-to-Agent Delegation
@@ -134,11 +134,20 @@ authProvider, _ := mcp.NewAuthProvider(
 
 ## Credential Types
 
-| Type                  | Auth Method                  | Use Case                                         |
-| --------------------- | ---------------------------- | ------------------------------------------------ |
-| `ClientSecret`        | HTTP Basic Auth              | Simple deployments with client_id/secret         |
-| `WebIdentity`         | `private_key_jwt` (RFC 7523) | Zero-secret deployments, auto-generates RSA keys |
-| `EKSWorkloadIdentity` | Pod identity token           | AWS EKS workloads                                |
+| Type               | Auth Method                      | Use Case                                                 |
+| ------------------ | -------------------------------- | -------------------------------------------------------- |
+| `ClientSecret`     | HTTP Basic Auth                  | Simple deployments with client_id/secret                 |
+| `WebIdentity`      | `private_key_jwt` (RFC 7523)     | Zero-secret deployments, auto-generates RSA keys         |
+| `WorkloadIdentity` | Platform OIDC token (jwt-bearer) | EKS, AKS, GKE, Cloud Run, Fly Machines, custom sources   |
+
+`WorkloadIdentity` takes a pluggable token source: `FileTokenSource` (projected token files: EKS, AKS, any Kubernetes projected service-account token), `GCPMetadataTokenSource` (GKE, GCE, Cloud Run), `FlyTokenSource` (Fly Machines), or any `SubjectTokenFunc`:
+
+```go
+source, _ := mcp.NewFileTokenSource() // discovers the projected token file from env
+credential, _ := mcp.NewWorkloadIdentity(source)
+```
+
+`EKSWorkloadIdentity` is deprecated: it is an alias for `WorkloadIdentity` with a `FileTokenSource` limited to EKS env-var discovery. Existing code keeps working; new code should use `NewWorkloadIdentity`.
 
 ## Error Handling
 

--- a/mcp/credentials.go
+++ b/mcp/credentials.go
@@ -301,18 +301,24 @@ func (w *WebIdentityCredential) ClientJWKSURL(resourceServerURL string) string {
 	return w.keyManager.ClientJWKSURL(resourceServerURL)
 }
 
-// EKSWorkloadIdentityCredential implements ApplicationCredential using AWS EKS pod identity tokens.
-type EKSWorkloadIdentityCredential struct {
-	tokenFilePath string
-}
+// EKSWorkloadIdentityCredential authenticates with an AWS EKS pod-identity
+// (projected service-account) token read from a mounted file.
+//
+// Deprecated: use NewWorkloadIdentity with NewFileTokenSource, which also
+// covers AKS and other platforms that project token files.
+type EKSWorkloadIdentityCredential = WorkloadIdentityCredential
 
+// defaultEKSEnvVars is the env-var discovery order for NewEKSWorkloadIdentity.
+// Unlike defaultFileTokenEnvVars it is limited to the EKS variables.
 var defaultEKSEnvVars = []string{
 	"KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE",
 	"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
 	"AWS_WEB_IDENTITY_TOKEN_FILE",
 }
 
-// EKSWorkloadIdentityOption configures an EKSWorkloadIdentityCredential.
+// EKSWorkloadIdentityOption configures NewEKSWorkloadIdentity.
+//
+// Deprecated: use FileTokenSourceOption with NewFileTokenSource.
 type EKSWorkloadIdentityOption func(*eksConfig)
 
 type eksConfig struct {
@@ -321,85 +327,36 @@ type eksConfig struct {
 }
 
 // WithTokenFilePath sets the path to the EKS token file directly.
+//
+// Deprecated: use WithFileTokenPath with NewFileTokenSource.
 func WithTokenFilePath(path string) EKSWorkloadIdentityOption {
 	return func(cfg *eksConfig) { cfg.tokenFilePath = path }
 }
 
 // WithEnvVarName adds a custom environment variable name to check for the token file path.
+//
+// Deprecated: use WithFileEnvVar with NewFileTokenSource.
 func WithEnvVarName(name string) EKSWorkloadIdentityOption {
 	return func(cfg *eksConfig) { cfg.envVarName = name }
 }
 
-// NewEKSWorkloadIdentity creates a new EKSWorkloadIdentityCredential.
+// NewEKSWorkloadIdentity creates a workload identity credential that reads the
+// EKS projected token file, with env-var discovery limited to the EKS
+// variables.
+//
+// Deprecated: use NewWorkloadIdentity with NewFileTokenSource.
 func NewEKSWorkloadIdentity(opts ...EKSWorkloadIdentityOption) (*EKSWorkloadIdentityCredential, error) {
 	cfg := eksConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
-	var tokenFilePath string
-	if cfg.tokenFilePath != "" {
-		tokenFilePath = cfg.tokenFilePath
-	} else {
-		envVars := defaultEKSEnvVars
-		if cfg.envVarName != "" {
-			envVars = append([]string{cfg.envVarName}, envVars...)
-		}
-
-		for _, envVar := range envVars {
-			if v := os.Getenv(envVar); v != "" {
-				tokenFilePath = v
-				break
-			}
-		}
-
-		if tokenFilePath == "" {
-			return nil, &EKSWorkloadIdentityConfigurationError{
-				Message: fmt.Sprintf("could not find token file path in environment variables; checked: %s",
-					strings.Join(envVars, ", ")),
-			}
-		}
-	}
-
-	// Validate that the token file exists and is non-empty
-	data, err := os.ReadFile(tokenFilePath)
+	source, err := newFileTokenSource(defaultEKSEnvVars, fileTokenSourceConfig{
+		tokenFilePath: cfg.tokenFilePath,
+		envVarName:    cfg.envVarName,
+	})
 	if err != nil {
-		return nil, &EKSWorkloadIdentityConfigurationError{
-			Message: fmt.Sprintf("error reading token file %q", tokenFilePath),
-			Err:     err,
-		}
+		return nil, err
 	}
-	if len(strings.TrimSpace(string(data))) == 0 {
-		return nil, &EKSWorkloadIdentityConfigurationError{
-			Message: fmt.Sprintf("token file is empty: %s", tokenFilePath),
-		}
-	}
-
-	return &EKSWorkloadIdentityCredential{tokenFilePath: tokenFilePath}, nil
-}
-
-// Auth returns nil (EKS uses assertion-based auth, not basic auth).
-func (e *EKSWorkloadIdentityCredential) Auth(_ string) *ClientAuth {
-	return nil
-}
-
-// PrepareTokenExchangeRequest builds a token exchange request with the EKS pod identity token.
-func (e *EKSWorkloadIdentityCredential) PrepareTokenExchangeRequest(_ context.Context, subjectToken, resource string, _ *PrepareOptions) (*oauth.TokenExchangeRequest, error) {
-	data, err := os.ReadFile(e.tokenFilePath)
-	if err != nil {
-		return nil, &EKSWorkloadIdentityRuntimeError{Message: fmt.Sprintf("reading EKS token from %q", e.tokenFilePath), Err: err}
-	}
-
-	eksToken := strings.TrimSpace(string(data))
-	if eksToken == "" {
-		return nil, &EKSWorkloadIdentityRuntimeError{Message: fmt.Sprintf("EKS token file is empty: %s", e.tokenFilePath)}
-	}
-
-	return &oauth.TokenExchangeRequest{
-		SubjectToken:        subjectToken,
-		Resource:            resource,
-		SubjectTokenType:    "urn:ietf:params:oauth:token-type:access_token",
-		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-		ClientAssertion:     eksToken,
-	}, nil
+	return NewWorkloadIdentity(source)
 }

--- a/mcp/doc.go
+++ b/mcp/doc.go
@@ -4,7 +4,7 @@
 //
 //   - Bearer auth middleware for protecting HTTP endpoints ([RequireBearerAuth])
 //   - Token exchange orchestration for delegated access ([AuthProvider], [AccessContext])
-//   - Application credential implementations ([ClientSecret], [WebIdentity], [EKSWorkloadIdentity])
+//   - Application credential implementations ([ClientSecret], [WebIdentity], [WorkloadIdentityCredential])
 //   - Well-known metadata endpoint handlers ([AuthMetadataHandler])
 //   - JWT token verification ([JWTOAuthTokenVerifier])
 //   - Private key management for client assertions ([PrivateKeyManager])

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -26,42 +26,63 @@ func (e *WebIdentityConfigurationError) Error() string {
 	return e.Message
 }
 
-// EKSWorkloadIdentityConfigurationError indicates invalid EKS workload identity configuration
-// detected at construction (e.g. no token file path, or the file is missing or empty). Err
-// carries the underlying cause (e.g. os.ErrNotExist or os.ErrPermission from reading the
-// token file) for errors.Is/errors.As, and is nil when there is no underlying error.
-type EKSWorkloadIdentityConfigurationError struct {
+// WorkloadIdentityConfigurationError indicates a workload identity credential
+// or token source was misconfigured at construction: a nil source, a missing,
+// unreadable, or empty token file, no discovery environment variable set, or
+// a missing required audience. Source identifies the token source ("file",
+// "gcp-metadata"; empty when the fault is in the credential itself). Err
+// carries the underlying cause (e.g. os.ErrNotExist or os.ErrPermission from
+// reading a token file) for errors.Is/errors.As, and is nil when there is no
+// underlying error.
+type WorkloadIdentityConfigurationError struct {
+	Source  string
 	Message string
 	Err     error
 }
 
-func (e *EKSWorkloadIdentityConfigurationError) Error() string {
+func (e *WorkloadIdentityConfigurationError) Error() string {
 	if e.Err != nil {
 		return e.Message + ": " + e.Err.Error()
 	}
 	return e.Message
 }
 
-func (e *EKSWorkloadIdentityConfigurationError) Unwrap() error { return e.Err }
+func (e *WorkloadIdentityConfigurationError) Unwrap() error { return e.Err }
 
-// EKSWorkloadIdentityRuntimeError indicates the EKS token could not be read at request
-// time (e.g. the token file was rotated away or emptied after construction). It is
-// distinct from EKSWorkloadIdentityConfigurationError, which is a construction-time fault.
-// Err carries the underlying read cause (e.g. os.ErrNotExist or os.ErrPermission) for
-// errors.Is/errors.As, and is nil when there is no underlying error (e.g. an empty token).
-type EKSWorkloadIdentityRuntimeError struct {
+// WorkloadIdentityRuntimeError indicates the subject token could not be
+// obtained at request time (e.g. the token file was rotated away or emptied
+// after construction, or the platform endpoint was unreachable). It is
+// distinct from WorkloadIdentityConfigurationError, which is a
+// construction-time fault. Source identifies the token source ("file",
+// "gcp-metadata", or "custom" for an adapted function). Err carries the
+// underlying cause for errors.Is/errors.As, and is nil when there is no
+// underlying error (e.g. an empty token).
+type WorkloadIdentityRuntimeError struct {
+	Source  string
 	Message string
 	Err     error
 }
 
-func (e *EKSWorkloadIdentityRuntimeError) Error() string {
+func (e *WorkloadIdentityRuntimeError) Error() string {
 	if e.Err != nil {
 		return e.Message + ": " + e.Err.Error()
 	}
 	return e.Message
 }
 
-func (e *EKSWorkloadIdentityRuntimeError) Unwrap() error { return e.Err }
+func (e *WorkloadIdentityRuntimeError) Unwrap() error { return e.Err }
+
+// EKSWorkloadIdentityConfigurationError indicates invalid workload identity
+// configuration at construction.
+//
+// Deprecated: use WorkloadIdentityConfigurationError.
+type EKSWorkloadIdentityConfigurationError = WorkloadIdentityConfigurationError
+
+// EKSWorkloadIdentityRuntimeError indicates the token could not be read at
+// request time.
+//
+// Deprecated: use WorkloadIdentityRuntimeError.
+type EKSWorkloadIdentityRuntimeError = WorkloadIdentityRuntimeError
 
 // ClientSecretConfigurationError indicates a ClientSecretCredential was constructed with
 // invalid configuration, such as an empty client_id or client_secret, or an empty

--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -30,7 +30,7 @@ func (e *WebIdentityConfigurationError) Error() string {
 // or token source was misconfigured at construction: a nil source, a missing,
 // unreadable, or empty token file, no discovery environment variable set, or
 // a missing required audience. Source identifies the token source ("file",
-// "gcp-metadata"; empty when the fault is in the credential itself). Err
+// "gcp-metadata", "fly"; empty when the fault is in the credential itself). Err
 // carries the underlying cause (e.g. os.ErrNotExist or os.ErrPermission from
 // reading a token file) for errors.Is/errors.As, and is nil when there is no
 // underlying error.
@@ -54,7 +54,8 @@ func (e *WorkloadIdentityConfigurationError) Unwrap() error { return e.Err }
 // after construction, or the platform endpoint was unreachable). It is
 // distinct from WorkloadIdentityConfigurationError, which is a
 // construction-time fault. Source identifies the token source ("file",
-// "gcp-metadata", or "custom" for an adapted function). Err carries the
+// "gcp-metadata", "fly", or "custom" for a source whose error is not one of
+// this package's typed errors). Err carries the
 // underlying cause for errors.Is/errors.As, and is nil when there is no
 // underlying error (e.g. an empty token).
 type WorkloadIdentityRuntimeError struct {

--- a/mcp/token_sources.go
+++ b/mcp/token_sources.go
@@ -120,8 +120,8 @@ func newFileTokenSource(discoveryEnvVars []string, cfg fileTokenSourceConfig) (*
 	return &FileTokenSource{tokenFilePath: tokenFilePath}, nil
 }
 
-// SubjectToken re-reads the token file and returns its trimmed contents.
-func (f *FileTokenSource) SubjectToken(_ context.Context) (string, error) {
+// IdentityToken re-reads the token file and returns its trimmed contents.
+func (f *FileTokenSource) IdentityToken(_ context.Context) (string, error) {
 	data, err := os.ReadFile(f.tokenFilePath)
 	if err != nil {
 		return "", &WorkloadIdentityRuntimeError{
@@ -193,8 +193,8 @@ func NewGCPMetadataTokenSource(audience string, opts ...GCPMetadataOption) (*GCP
 	return g, nil
 }
 
-// SubjectToken requests a GCP-signed OIDC JWT from the metadata server.
-func (g *GCPMetadataTokenSource) SubjectToken(ctx context.Context) (string, error) {
+// IdentityToken requests a GCP-signed OIDC JWT from the metadata server.
+func (g *GCPMetadataTokenSource) IdentityToken(ctx context.Context) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, g.timeout)
 	defer cancel()
 
@@ -293,8 +293,8 @@ func NewFlyTokenSource(opts ...FlyTokenSourceOption) *FlyTokenSource {
 	return f
 }
 
-// SubjectToken requests a Fly-signed OIDC JWT from the Machines API.
-func (f *FlyTokenSource) SubjectToken(ctx context.Context) (string, error) {
+// IdentityToken requests a Fly-signed OIDC JWT from the Machines API.
+func (f *FlyTokenSource) IdentityToken(ctx context.Context) (string, error) {
 	payload := struct {
 		Aud string `json:"aud,omitempty"`
 	}{Aud: f.audience}

--- a/mcp/token_sources.go
+++ b/mcp/token_sources.go
@@ -1,0 +1,246 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Source identifiers carried in the Source field of
+// WorkloadIdentityConfigurationError and WorkloadIdentityRuntimeError.
+const (
+	workloadIdentitySourceFile        = "file"
+	workloadIdentitySourceGCPMetadata = "gcp-metadata"
+	workloadIdentitySourceCustom      = "custom"
+)
+
+// defaultFileTokenEnvVars is the env-var discovery order for
+// NewFileTokenSource: the EKS pod-identity variables followed by the AKS
+// federated-token variable.
+var defaultFileTokenEnvVars = []string{
+	"KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE",
+	"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+	"AWS_WEB_IDENTITY_TOKEN_FILE",
+	"AZURE_FEDERATED_TOKEN_FILE",
+}
+
+// FileTokenSource reads a platform-projected OIDC token from a mounted file,
+// fresh on every call (platforms rotate projected tokens). It covers EKS pod
+// identity, AKS workload identity, any Kubernetes projected service-account
+// token, and CI providers that write the token to a file.
+type FileTokenSource struct {
+	tokenFilePath string
+}
+
+type fileTokenSourceConfig struct {
+	tokenFilePath string
+	envVarName    string
+}
+
+// FileTokenSourceOption configures a FileTokenSource.
+type FileTokenSourceOption func(*fileTokenSourceConfig)
+
+// WithFileTokenPath sets the token file path directly, skipping env-var
+// discovery.
+func WithFileTokenPath(path string) FileTokenSourceOption {
+	return func(cfg *fileTokenSourceConfig) { cfg.tokenFilePath = path }
+}
+
+// WithFileEnvVar adds an environment variable to consult first during
+// discovery, ahead of the default list.
+func WithFileEnvVar(name string) FileTokenSourceOption {
+	return func(cfg *fileTokenSourceConfig) { cfg.envVarName = name }
+}
+
+// NewFileTokenSource creates a FileTokenSource. When no explicit path is
+// given, the path is discovered from the first set environment variable,
+// checking the variable given via WithFileEnvVar first, then
+// KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE, AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE,
+// AWS_WEB_IDENTITY_TOKEN_FILE, and AZURE_FEDERATED_TOKEN_FILE. It returns a
+// WorkloadIdentityConfigurationError when no path can be resolved or the
+// resolved file is missing, unreadable, or empty.
+func NewFileTokenSource(opts ...FileTokenSourceOption) (*FileTokenSource, error) {
+	cfg := fileTokenSourceConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return newFileTokenSource(defaultFileTokenEnvVars, cfg)
+}
+
+func newFileTokenSource(discoveryEnvVars []string, cfg fileTokenSourceConfig) (*FileTokenSource, error) {
+	tokenFilePath := cfg.tokenFilePath
+	if tokenFilePath == "" {
+		envVars := discoveryEnvVars
+		if cfg.envVarName != "" {
+			envVars = append([]string{cfg.envVarName}, envVars...)
+		}
+
+		for _, envVar := range envVars {
+			if v := os.Getenv(envVar); v != "" {
+				tokenFilePath = v
+				break
+			}
+		}
+
+		if tokenFilePath == "" {
+			return nil, &WorkloadIdentityConfigurationError{
+				Source: workloadIdentitySourceFile,
+				Message: fmt.Sprintf("could not find token file path in environment variables; checked: %s",
+					strings.Join(envVars, ", ")),
+			}
+		}
+	}
+
+	// Validate that the token file exists and is non-empty
+	data, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		return nil, &WorkloadIdentityConfigurationError{
+			Source:  workloadIdentitySourceFile,
+			Message: fmt.Sprintf("error reading token file %q", tokenFilePath),
+			Err:     err,
+		}
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, &WorkloadIdentityConfigurationError{
+			Source:  workloadIdentitySourceFile,
+			Message: fmt.Sprintf("token file is empty: %s", tokenFilePath),
+		}
+	}
+
+	return &FileTokenSource{tokenFilePath: tokenFilePath}, nil
+}
+
+// SubjectToken re-reads the token file and returns its trimmed contents.
+func (f *FileTokenSource) SubjectToken(_ context.Context) (string, error) {
+	data, err := os.ReadFile(f.tokenFilePath)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceFile,
+			Message: fmt.Sprintf("reading token file %q", f.tokenFilePath),
+			Err:     err,
+		}
+	}
+
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceFile,
+			Message: fmt.Sprintf("token file is empty: %s", f.tokenFilePath),
+		}
+	}
+	return token, nil
+}
+
+const (
+	defaultGCPMetadataURL     = "http://metadata.google.internal"
+	defaultGCPMetadataTimeout = 5 * time.Second
+	gcpMetadataIdentityPath   = "/computeMetadata/v1/instance/service-accounts/default/identity"
+)
+
+// GCPMetadataTokenSource fetches an OIDC identity token for the default
+// service account from the GCP metadata server. It covers GKE, GCE, and
+// Cloud Run.
+type GCPMetadataTokenSource struct {
+	audience    string
+	metadataURL string
+	httpClient  *http.Client
+	timeout     time.Duration
+}
+
+// GCPMetadataOption configures a GCPMetadataTokenSource.
+type GCPMetadataOption func(*GCPMetadataTokenSource)
+
+// WithGCPMetadataURL overrides the metadata server base URL (for testing).
+func WithGCPMetadataURL(u string) GCPMetadataOption {
+	return func(g *GCPMetadataTokenSource) { g.metadataURL = u }
+}
+
+// WithGCPHTTPClient overrides the HTTP client used for metadata requests.
+func WithGCPHTTPClient(c *http.Client) GCPMetadataOption {
+	return func(g *GCPMetadataTokenSource) { g.httpClient = c }
+}
+
+// WithGCPTimeout overrides the per-call deadline for metadata requests.
+func WithGCPTimeout(d time.Duration) GCPMetadataOption {
+	return func(g *GCPMetadataTokenSource) { g.timeout = d }
+}
+
+// NewGCPMetadataTokenSource creates a GCPMetadataTokenSource that requests
+// tokens for the given audience, typically the Keycard zone URL. It returns a
+// WorkloadIdentityConfigurationError if audience is empty.
+func NewGCPMetadataTokenSource(audience string, opts ...GCPMetadataOption) (*GCPMetadataTokenSource, error) {
+	if strings.TrimSpace(audience) == "" {
+		return nil, &WorkloadIdentityConfigurationError{
+			Source:  workloadIdentitySourceGCPMetadata,
+			Message: "audience must not be empty",
+		}
+	}
+
+	g := &GCPMetadataTokenSource{
+		audience:    audience,
+		metadataURL: defaultGCPMetadataURL,
+		httpClient:  &http.Client{},
+		timeout:     defaultGCPMetadataTimeout,
+	}
+	for _, opt := range opts {
+		opt(g)
+	}
+	return g, nil
+}
+
+// SubjectToken requests a GCP-signed OIDC JWT from the metadata server.
+func (g *GCPMetadataTokenSource) SubjectToken(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, g.timeout)
+	defer cancel()
+
+	metaURL := g.metadataURL + gcpMetadataIdentityPath +
+		"?audience=" + url.QueryEscape(g.audience) + "&format=full"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceGCPMetadata,
+			Message: "building metadata request",
+			Err:     err,
+		}
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceGCPMetadata,
+			Message: fmt.Sprintf("calling metadata server at %s (is this running on GCP?)", g.metadataURL),
+			Err:     err,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceGCPMetadata,
+			Message: "reading metadata response",
+			Err:     err,
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceGCPMetadata,
+			Message: fmt.Sprintf("metadata server returned status %d", resp.StatusCode),
+		}
+	}
+
+	token := strings.TrimSpace(string(body))
+	if token == "" {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  workloadIdentitySourceGCPMetadata,
+			Message: "metadata server returned an empty token",
+		}
+	}
+	return token, nil
+}

--- a/mcp/token_sources.go
+++ b/mcp/token_sources.go
@@ -1,9 +1,12 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,11 +15,13 @@ import (
 )
 
 // Source identifiers carried in the Source field of
-// WorkloadIdentityConfigurationError and WorkloadIdentityRuntimeError.
+// WorkloadIdentityConfigurationError and WorkloadIdentityRuntimeError, for
+// branching on which token source failed.
 const (
-	workloadIdentitySourceFile        = "file"
-	workloadIdentitySourceGCPMetadata = "gcp-metadata"
-	workloadIdentitySourceCustom      = "custom"
+	WorkloadIdentitySourceFile        = "file"
+	WorkloadIdentitySourceGCPMetadata = "gcp-metadata"
+	WorkloadIdentitySourceFly         = "fly"
+	WorkloadIdentitySourceCustom      = "custom"
 )
 
 // defaultFileTokenEnvVars is the env-var discovery order for
@@ -89,7 +94,7 @@ func newFileTokenSource(discoveryEnvVars []string, cfg fileTokenSourceConfig) (*
 
 		if tokenFilePath == "" {
 			return nil, &WorkloadIdentityConfigurationError{
-				Source: workloadIdentitySourceFile,
+				Source: WorkloadIdentitySourceFile,
 				Message: fmt.Sprintf("could not find token file path in environment variables; checked: %s",
 					strings.Join(envVars, ", ")),
 			}
@@ -100,14 +105,14 @@ func newFileTokenSource(discoveryEnvVars []string, cfg fileTokenSourceConfig) (*
 	data, err := os.ReadFile(tokenFilePath)
 	if err != nil {
 		return nil, &WorkloadIdentityConfigurationError{
-			Source:  workloadIdentitySourceFile,
+			Source:  WorkloadIdentitySourceFile,
 			Message: fmt.Sprintf("error reading token file %q", tokenFilePath),
 			Err:     err,
 		}
 	}
 	if len(strings.TrimSpace(string(data))) == 0 {
 		return nil, &WorkloadIdentityConfigurationError{
-			Source:  workloadIdentitySourceFile,
+			Source:  WorkloadIdentitySourceFile,
 			Message: fmt.Sprintf("token file is empty: %s", tokenFilePath),
 		}
 	}
@@ -120,7 +125,7 @@ func (f *FileTokenSource) SubjectToken(_ context.Context) (string, error) {
 	data, err := os.ReadFile(f.tokenFilePath)
 	if err != nil {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceFile,
+			Source:  WorkloadIdentitySourceFile,
 			Message: fmt.Sprintf("reading token file %q", f.tokenFilePath),
 			Err:     err,
 		}
@@ -129,7 +134,7 @@ func (f *FileTokenSource) SubjectToken(_ context.Context) (string, error) {
 	token := strings.TrimSpace(string(data))
 	if token == "" {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceFile,
+			Source:  WorkloadIdentitySourceFile,
 			Message: fmt.Sprintf("token file is empty: %s", f.tokenFilePath),
 		}
 	}
@@ -160,11 +165,6 @@ func WithGCPMetadataURL(u string) GCPMetadataOption {
 	return func(g *GCPMetadataTokenSource) { g.metadataURL = u }
 }
 
-// WithGCPHTTPClient overrides the HTTP client used for metadata requests.
-func WithGCPHTTPClient(c *http.Client) GCPMetadataOption {
-	return func(g *GCPMetadataTokenSource) { g.httpClient = c }
-}
-
 // WithGCPTimeout overrides the per-call deadline for metadata requests.
 func WithGCPTimeout(d time.Duration) GCPMetadataOption {
 	return func(g *GCPMetadataTokenSource) { g.timeout = d }
@@ -176,7 +176,7 @@ func WithGCPTimeout(d time.Duration) GCPMetadataOption {
 func NewGCPMetadataTokenSource(audience string, opts ...GCPMetadataOption) (*GCPMetadataTokenSource, error) {
 	if strings.TrimSpace(audience) == "" {
 		return nil, &WorkloadIdentityConfigurationError{
-			Source:  workloadIdentitySourceGCPMetadata,
+			Source:  WorkloadIdentitySourceGCPMetadata,
 			Message: "audience must not be empty",
 		}
 	}
@@ -203,7 +203,7 @@ func (g *GCPMetadataTokenSource) SubjectToken(ctx context.Context) (string, erro
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
 	if err != nil {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceGCPMetadata,
+			Source:  WorkloadIdentitySourceGCPMetadata,
 			Message: "building metadata request",
 			Err:     err,
 		}
@@ -213,7 +213,7 @@ func (g *GCPMetadataTokenSource) SubjectToken(ctx context.Context) (string, erro
 	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceGCPMetadata,
+			Source:  WorkloadIdentitySourceGCPMetadata,
 			Message: fmt.Sprintf("calling metadata server at %s (is this running on GCP?)", g.metadataURL),
 			Err:     err,
 		}
@@ -223,14 +223,14 @@ func (g *GCPMetadataTokenSource) SubjectToken(ctx context.Context) (string, erro
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceGCPMetadata,
+			Source:  WorkloadIdentitySourceGCPMetadata,
 			Message: "reading metadata response",
 			Err:     err,
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceGCPMetadata,
+			Source:  WorkloadIdentitySourceGCPMetadata,
 			Message: fmt.Sprintf("metadata server returned status %d", resp.StatusCode),
 		}
 	}
@@ -238,8 +238,115 @@ func (g *GCPMetadataTokenSource) SubjectToken(ctx context.Context) (string, erro
 	token := strings.TrimSpace(string(body))
 	if token == "" {
 		return "", &WorkloadIdentityRuntimeError{
-			Source:  workloadIdentitySourceGCPMetadata,
+			Source:  WorkloadIdentitySourceGCPMetadata,
 			Message: "metadata server returned an empty token",
+		}
+	}
+	return token, nil
+}
+
+const (
+	defaultFlySocketPath = "/.fly/api"
+	flyOIDCTokenURL      = "http://localhost/v1/tokens/oidc"
+	flyRequestTimeout    = 5 * time.Second
+)
+
+// FlyTokenSource fetches an OIDC token from the Fly.io Machines API over the
+// local Unix socket. It covers workloads running on Fly Machines.
+type FlyTokenSource struct {
+	audience   string
+	socketPath string
+	httpClient *http.Client
+}
+
+// FlyTokenSourceOption configures a FlyTokenSource.
+type FlyTokenSourceOption func(*FlyTokenSource)
+
+// WithFlyAudience sets the audience claim for the requested token, typically
+// the Keycard zone URL.
+func WithFlyAudience(audience string) FlyTokenSourceOption {
+	return func(f *FlyTokenSource) { f.audience = audience }
+}
+
+// WithFlySocketPath overrides the Machines API socket path (default /.fly/api).
+func WithFlySocketPath(path string) FlyTokenSourceOption {
+	return func(f *FlyTokenSource) { f.socketPath = path }
+}
+
+// NewFlyTokenSource creates a FlyTokenSource. The socket is not probed at
+// construction; an unreachable Machines API surfaces as a
+// WorkloadIdentityRuntimeError at the first fetch.
+func NewFlyTokenSource(opts ...FlyTokenSourceOption) *FlyTokenSource {
+	f := &FlyTokenSource{socketPath: defaultFlySocketPath}
+	for _, opt := range opts {
+		opt(f)
+	}
+	f.httpClient = &http.Client{
+		Timeout: flyRequestTimeout,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", f.socketPath)
+			},
+		},
+	}
+	return f
+}
+
+// SubjectToken requests a Fly-signed OIDC JWT from the Machines API.
+func (f *FlyTokenSource) SubjectToken(ctx context.Context) (string, error) {
+	payload := struct {
+		Aud string `json:"aud,omitempty"`
+	}{Aud: f.audience}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  WorkloadIdentitySourceFly,
+			Message: "encoding token request",
+			Err:     err,
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, flyOIDCTokenURL, bytes.NewReader(body))
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  WorkloadIdentitySourceFly,
+			Message: "building token request",
+			Err:     err,
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  WorkloadIdentitySourceFly,
+			Message: fmt.Sprintf("calling Machines API socket %s (is this running on a Fly Machine?)", f.socketPath),
+			Err:     err,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  WorkloadIdentitySourceFly,
+			Message: "reading token response",
+			Err:     err,
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  WorkloadIdentitySourceFly,
+			Message: fmt.Sprintf("Machines API returned status %d", resp.StatusCode),
+		}
+	}
+
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", &WorkloadIdentityRuntimeError{
+			Source:  WorkloadIdentitySourceFly,
+			Message: "Machines API returned an empty token",
 		}
 	}
 	return token, nil

--- a/mcp/workload_identity.go
+++ b/mcp/workload_identity.go
@@ -39,10 +39,14 @@ type WorkloadIdentityCredential struct {
 }
 
 // NewWorkloadIdentity creates a WorkloadIdentityCredential backed by source.
-// It returns a WorkloadIdentityConfigurationError if source is nil.
+// It returns a WorkloadIdentityConfigurationError if source is nil (including
+// a nil SubjectTokenFunc).
 func NewWorkloadIdentity(source SubjectTokenSource) (*WorkloadIdentityCredential, error) {
 	if source == nil {
 		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source must not be nil"}
+	}
+	if f, ok := source.(SubjectTokenFunc); ok && f == nil {
+		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source function must not be nil"}
 	}
 	return &WorkloadIdentityCredential{source: source}, nil
 }
@@ -65,10 +69,10 @@ func (w *WorkloadIdentityCredential) PrepareTokenExchangeRequest(ctx context.Con
 		if errors.As(err, &runtimeErr) || errors.As(err, &cfgErr) {
 			return nil, err
 		}
-		return nil, &WorkloadIdentityRuntimeError{Source: workloadIdentitySourceCustom, Message: "fetching subject token", Err: err}
+		return nil, &WorkloadIdentityRuntimeError{Source: WorkloadIdentitySourceCustom, Message: "fetching subject token", Err: err}
 	}
 	if strings.TrimSpace(assertion) == "" {
-		return nil, &WorkloadIdentityRuntimeError{Source: workloadIdentitySourceCustom, Message: "subject token source returned an empty token"}
+		return nil, &WorkloadIdentityRuntimeError{Source: WorkloadIdentitySourceCustom, Message: "subject token source returned an empty token"}
 	}
 
 	return &oauth.TokenExchangeRequest{

--- a/mcp/workload_identity.go
+++ b/mcp/workload_identity.go
@@ -35,20 +35,37 @@ func (f SubjectTokenFunc) SubjectToken(ctx context.Context) (string, error) { re
 // as a jwt-bearer client assertion. It holds no shared secret and never
 // caches the token across requests.
 type WorkloadIdentityCredential struct {
-	source SubjectTokenSource
+	source   SubjectTokenSource
+	clientID string
+}
+
+// WorkloadIdentityOption configures a WorkloadIdentityCredential.
+type WorkloadIdentityOption func(*WorkloadIdentityCredential)
+
+// WithWorkloadClientID sets the ID of the Keycard application credential this
+// workload authenticates as. It is sent as the client_id form parameter
+// alongside the client assertion. Token-federation application credentials
+// are resolved by this ID, so they require it; legacy token credentials are
+// resolved by the assertion's subject and ignore it.
+func WithWorkloadClientID(clientID string) WorkloadIdentityOption {
+	return func(w *WorkloadIdentityCredential) { w.clientID = clientID }
 }
 
 // NewWorkloadIdentity creates a WorkloadIdentityCredential backed by source.
 // It returns a WorkloadIdentityConfigurationError if source is nil (including
 // a nil SubjectTokenFunc).
-func NewWorkloadIdentity(source SubjectTokenSource) (*WorkloadIdentityCredential, error) {
+func NewWorkloadIdentity(source SubjectTokenSource, opts ...WorkloadIdentityOption) (*WorkloadIdentityCredential, error) {
 	if source == nil {
 		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source must not be nil"}
 	}
 	if f, ok := source.(SubjectTokenFunc); ok && f == nil {
 		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source function must not be nil"}
 	}
-	return &WorkloadIdentityCredential{source: source}, nil
+	w := &WorkloadIdentityCredential{source: source}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w, nil
 }
 
 // Auth returns nil (workload identity uses assertion-based auth, not basic auth).
@@ -81,5 +98,6 @@ func (w *WorkloadIdentityCredential) PrepareTokenExchangeRequest(ctx context.Con
 		SubjectTokenType:    "urn:ietf:params:oauth:token-type:access_token",
 		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
 		ClientAssertion:     assertion,
+		ClientID:            w.clientID,
 	}, nil
 }

--- a/mcp/workload_identity.go
+++ b/mcp/workload_identity.go
@@ -8,34 +8,34 @@ import (
 	"github.com/keycardai/go-sdk/oauth"
 )
 
-// SubjectTokenSource supplies a platform-signed OIDC token for use as a client
+// IdentityTokenSource supplies a platform-signed OIDC token for use as a client
 // assertion during token exchange. It is the only per-platform piece of a
 // workload identity credential: [FileTokenSource] covers platforms that
 // project the token to a file (EKS, AKS, Kubernetes projected service-account
 // tokens), [GCPMetadataTokenSource] covers platforms that serve it from the
-// GCP metadata endpoint (GKE, GCE, Cloud Run), and [SubjectTokenFunc] adapts
+// GCP metadata endpoint (GKE, GCE, Cloud Run), and [IdentityTokenFunc] adapts
 // any custom fetch.
 //
-// SubjectToken is called on every token exchange. Implementations must return
+// IdentityToken is called on every token exchange. Implementations must return
 // the current token; platforms rotate these tokens, so returning a stale
 // cached value risks an expired assertion.
-type SubjectTokenSource interface {
-	SubjectToken(ctx context.Context) (string, error)
+type IdentityTokenSource interface {
+	IdentityToken(ctx context.Context) (string, error)
 }
 
-// SubjectTokenFunc adapts a function to a SubjectTokenSource.
-type SubjectTokenFunc func(ctx context.Context) (string, error)
+// IdentityTokenFunc adapts a function to a IdentityTokenSource.
+type IdentityTokenFunc func(ctx context.Context) (string, error)
 
-// SubjectToken implements SubjectTokenSource.
-func (f SubjectTokenFunc) SubjectToken(ctx context.Context) (string, error) { return f(ctx) }
+// IdentityToken implements IdentityTokenSource.
+func (f IdentityTokenFunc) IdentityToken(ctx context.Context) (string, error) { return f(ctx) }
 
 // WorkloadIdentityCredential implements ApplicationCredential using a
-// platform-signed OIDC token obtained from a SubjectTokenSource. On every
+// platform-signed OIDC token obtained from a IdentityTokenSource. On every
 // token exchange it fetches the current token from the source and attaches it
 // as a jwt-bearer client assertion. It holds no shared secret and never
 // caches the token across requests.
 type WorkloadIdentityCredential struct {
-	source   SubjectTokenSource
+	source   IdentityTokenSource
 	clientID string
 }
 
@@ -53,13 +53,13 @@ func WithWorkloadClientID(clientID string) WorkloadIdentityOption {
 
 // NewWorkloadIdentity creates a WorkloadIdentityCredential backed by source.
 // It returns a WorkloadIdentityConfigurationError if source is nil (including
-// a nil SubjectTokenFunc).
-func NewWorkloadIdentity(source SubjectTokenSource, opts ...WorkloadIdentityOption) (*WorkloadIdentityCredential, error) {
+// a nil IdentityTokenFunc).
+func NewWorkloadIdentity(source IdentityTokenSource, opts ...WorkloadIdentityOption) (*WorkloadIdentityCredential, error) {
 	if source == nil {
-		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source must not be nil"}
+		return nil, &WorkloadIdentityConfigurationError{Message: "identity token source must not be nil"}
 	}
-	if f, ok := source.(SubjectTokenFunc); ok && f == nil {
-		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source function must not be nil"}
+	if f, ok := source.(IdentityTokenFunc); ok && f == nil {
+		return nil, &WorkloadIdentityConfigurationError{Message: "identity token source function must not be nil"}
 	}
 	w := &WorkloadIdentityCredential{source: source}
 	for _, opt := range opts {
@@ -79,17 +79,17 @@ func (w *WorkloadIdentityCredential) Auth(_ string) *ClientAuth {
 // other source error is wrapped in a WorkloadIdentityRuntimeError with
 // Source "custom".
 func (w *WorkloadIdentityCredential) PrepareTokenExchangeRequest(ctx context.Context, subjectToken, resource string, _ *PrepareOptions) (*oauth.TokenExchangeRequest, error) {
-	assertion, err := w.source.SubjectToken(ctx)
+	assertion, err := w.source.IdentityToken(ctx)
 	if err != nil {
 		var cfgErr *WorkloadIdentityConfigurationError
 		var runtimeErr *WorkloadIdentityRuntimeError
 		if errors.As(err, &runtimeErr) || errors.As(err, &cfgErr) {
 			return nil, err
 		}
-		return nil, &WorkloadIdentityRuntimeError{Source: WorkloadIdentitySourceCustom, Message: "fetching subject token", Err: err}
+		return nil, &WorkloadIdentityRuntimeError{Source: WorkloadIdentitySourceCustom, Message: "fetching identity token", Err: err}
 	}
 	if strings.TrimSpace(assertion) == "" {
-		return nil, &WorkloadIdentityRuntimeError{Source: WorkloadIdentitySourceCustom, Message: "subject token source returned an empty token"}
+		return nil, &WorkloadIdentityRuntimeError{Source: WorkloadIdentitySourceCustom, Message: "identity token source returned an empty token"}
 	}
 
 	return &oauth.TokenExchangeRequest{

--- a/mcp/workload_identity.go
+++ b/mcp/workload_identity.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/keycardai/go-sdk/oauth"
+)
+
+// SubjectTokenSource supplies a platform-signed OIDC token for use as a client
+// assertion during token exchange. It is the only per-platform piece of a
+// workload identity credential: [FileTokenSource] covers platforms that
+// project the token to a file (EKS, AKS, Kubernetes projected service-account
+// tokens), [GCPMetadataTokenSource] covers platforms that serve it from the
+// GCP metadata endpoint (GKE, GCE, Cloud Run), and [SubjectTokenFunc] adapts
+// any custom fetch.
+//
+// SubjectToken is called on every token exchange. Implementations must return
+// the current token; platforms rotate these tokens, so returning a stale
+// cached value risks an expired assertion.
+type SubjectTokenSource interface {
+	SubjectToken(ctx context.Context) (string, error)
+}
+
+// SubjectTokenFunc adapts a function to a SubjectTokenSource.
+type SubjectTokenFunc func(ctx context.Context) (string, error)
+
+// SubjectToken implements SubjectTokenSource.
+func (f SubjectTokenFunc) SubjectToken(ctx context.Context) (string, error) { return f(ctx) }
+
+// WorkloadIdentityCredential implements ApplicationCredential using a
+// platform-signed OIDC token obtained from a SubjectTokenSource. On every
+// token exchange it fetches the current token from the source and attaches it
+// as a jwt-bearer client assertion. It holds no shared secret and never
+// caches the token across requests.
+type WorkloadIdentityCredential struct {
+	source SubjectTokenSource
+}
+
+// NewWorkloadIdentity creates a WorkloadIdentityCredential backed by source.
+// It returns a WorkloadIdentityConfigurationError if source is nil.
+func NewWorkloadIdentity(source SubjectTokenSource) (*WorkloadIdentityCredential, error) {
+	if source == nil {
+		return nil, &WorkloadIdentityConfigurationError{Message: "subject token source must not be nil"}
+	}
+	return &WorkloadIdentityCredential{source: source}, nil
+}
+
+// Auth returns nil (workload identity uses assertion-based auth, not basic auth).
+func (w *WorkloadIdentityCredential) Auth(_ string) *ClientAuth {
+	return nil
+}
+
+// PrepareTokenExchangeRequest builds a token exchange request with the current
+// platform token as the client assertion. Built-in sources fail with
+// WorkloadIdentityConfigurationError or WorkloadIdentityRuntimeError; any
+// other source error is wrapped in a WorkloadIdentityRuntimeError with
+// Source "custom".
+func (w *WorkloadIdentityCredential) PrepareTokenExchangeRequest(ctx context.Context, subjectToken, resource string, _ *PrepareOptions) (*oauth.TokenExchangeRequest, error) {
+	assertion, err := w.source.SubjectToken(ctx)
+	if err != nil {
+		var cfgErr *WorkloadIdentityConfigurationError
+		var runtimeErr *WorkloadIdentityRuntimeError
+		if errors.As(err, &runtimeErr) || errors.As(err, &cfgErr) {
+			return nil, err
+		}
+		return nil, &WorkloadIdentityRuntimeError{Source: workloadIdentitySourceCustom, Message: "fetching subject token", Err: err}
+	}
+	if strings.TrimSpace(assertion) == "" {
+		return nil, &WorkloadIdentityRuntimeError{Source: workloadIdentitySourceCustom, Message: "subject token source returned an empty token"}
+	}
+
+	return &oauth.TokenExchangeRequest{
+		SubjectToken:        subjectToken,
+		Resource:            resource,
+		SubjectTokenType:    "urn:ietf:params:oauth:token-type:access_token",
+		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+		ClientAssertion:     assertion,
+	}, nil
+}

--- a/mcp/workload_identity_test.go
+++ b/mcp/workload_identity_test.go
@@ -493,3 +493,35 @@ func TestFlyTokenSource_RuntimeErrorOnFailure(t *testing.T) {
 		}
 	})
 }
+
+func TestWorkloadIdentity_ClientID(t *testing.T) {
+	source := SubjectTokenFunc(func(_ context.Context) (string, error) { return "platform-token", nil })
+
+	t.Run("set", func(t *testing.T) {
+		cred, err := NewWorkloadIdentity(source, WithWorkloadClientID("acr_123"))
+		if err != nil {
+			t.Fatalf("constructing credential: %v", err)
+		}
+		req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+		if err != nil {
+			t.Fatalf("preparing request: %v", err)
+		}
+		if req.ClientID != "acr_123" {
+			t.Errorf("client id: got %q, want the configured credential id", req.ClientID)
+		}
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		cred, err := NewWorkloadIdentity(source)
+		if err != nil {
+			t.Fatalf("constructing credential: %v", err)
+		}
+		req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+		if err != nil {
+			t.Fatalf("preparing request: %v", err)
+		}
+		if req.ClientID != "" {
+			t.Errorf("client id: got %q, want empty when not configured", req.ClientID)
+		}
+	})
+}

--- a/mcp/workload_identity_test.go
+++ b/mcp/workload_identity_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -368,4 +370,126 @@ func TestGCPMetadataTokenSource_RuntimeErrorWhenUnreachable(t *testing.T) {
 	if runtimeErr.Err == nil {
 		t.Error("Err: got nil, want the underlying transport error preserved")
 	}
+}
+
+func TestNewWorkloadIdentity_RejectsNilFunc(t *testing.T) {
+	cred, err := NewWorkloadIdentity(SubjectTokenFunc(nil))
+
+	var cfgErr *WorkloadIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityConfigurationError", err)
+	}
+	if cred != nil {
+		t.Errorf("credential: got %v, want nil on error", cred)
+	}
+}
+
+// startFlySocketServer serves handler on a Unix socket and returns the socket
+// path. It uses os.MkdirTemp rather than t.TempDir to keep the path under the
+// platform's Unix socket path length limit.
+func startFlySocketServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "fly")
+	if err != nil {
+		t.Fatalf("creating socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	socketPath := filepath.Join(dir, "api.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listening on unix socket: %v", err)
+	}
+
+	server := &http.Server{Handler: handler}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	return socketPath
+}
+
+func TestFlyTokenSource_RequestShape(t *testing.T) {
+	socketPath := startFlySocketServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/tokens/oidc" {
+			t.Errorf("path: got %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type: got %q", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		if string(body) != `{"aud":"https://zone.example.com"}` {
+			t.Errorf("body: got %s, want audience in JSON body", body)
+		}
+		_, _ = w.Write([]byte("fly-oidc-token\n"))
+	}))
+
+	source := NewFlyTokenSource(
+		WithFlyAudience("https://zone.example.com"),
+		WithFlySocketPath(socketPath),
+	)
+
+	token, err := source.SubjectToken(context.Background())
+	if err != nil {
+		t.Fatalf("fetching token: %v", err)
+	}
+	if token != "fly-oidc-token" {
+		t.Errorf("token: got %q, want trimmed response body", token)
+	}
+}
+
+func TestFlyTokenSource_EmptyObjectBodyWithoutAudience(t *testing.T) {
+	socketPath := startFlySocketServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		if string(body) != `{}` {
+			t.Errorf("body: got %s, want {} when no audience is set", body)
+		}
+		_, _ = w.Write([]byte("fly-oidc-token"))
+	}))
+
+	source := NewFlyTokenSource(WithFlySocketPath(socketPath))
+
+	if _, err := source.SubjectToken(context.Background()); err != nil {
+		t.Fatalf("fetching token: %v", err)
+	}
+}
+
+func TestFlyTokenSource_RuntimeErrorOnFailure(t *testing.T) {
+	t.Run("non-200 status", func(t *testing.T) {
+		socketPath := startFlySocketServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "machine not found", http.StatusNotFound)
+		}))
+		source := NewFlyTokenSource(WithFlySocketPath(socketPath))
+
+		_, err := source.SubjectToken(context.Background())
+		var runtimeErr *WorkloadIdentityRuntimeError
+		if !errors.As(err, &runtimeErr) {
+			t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+		}
+		if runtimeErr.Source != WorkloadIdentitySourceFly {
+			t.Errorf("source: got %q, want %q", runtimeErr.Source, WorkloadIdentitySourceFly)
+		}
+	})
+
+	t.Run("socket missing", func(t *testing.T) {
+		source := NewFlyTokenSource(WithFlySocketPath(filepath.Join(t.TempDir(), "no-such.sock")))
+
+		_, err := source.SubjectToken(context.Background())
+		var runtimeErr *WorkloadIdentityRuntimeError
+		if !errors.As(err, &runtimeErr) {
+			t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+		}
+		if runtimeErr.Err == nil {
+			t.Error("Err: got nil, want the underlying dial error preserved")
+		}
+	})
 }

--- a/mcp/workload_identity_test.go
+++ b/mcp/workload_identity_test.go
@@ -26,7 +26,7 @@ func TestNewWorkloadIdentity_RejectsNilSource(t *testing.T) {
 }
 
 func TestWorkloadIdentity_PreparesRequestFromSource(t *testing.T) {
-	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+	cred, err := NewWorkloadIdentity(IdentityTokenFunc(func(_ context.Context) (string, error) {
 		return "platform-token", nil
 	}))
 	if err != nil {
@@ -60,7 +60,7 @@ func TestWorkloadIdentity_PreparesRequestFromSource(t *testing.T) {
 
 func TestWorkloadIdentity_FetchesFreshTokenEveryExchange(t *testing.T) {
 	calls := 0
-	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+	cred, err := NewWorkloadIdentity(IdentityTokenFunc(func(_ context.Context) (string, error) {
 		calls++
 		return fmt.Sprintf("token-%d", calls), nil
 	}))
@@ -84,7 +84,7 @@ func TestWorkloadIdentity_FetchesFreshTokenEveryExchange(t *testing.T) {
 
 func TestWorkloadIdentity_WrapsCustomSourceError(t *testing.T) {
 	cause := errors.New("socket unavailable")
-	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+	cred, err := NewWorkloadIdentity(IdentityTokenFunc(func(_ context.Context) (string, error) {
 		return "", cause
 	}))
 	if err != nil {
@@ -106,7 +106,7 @@ func TestWorkloadIdentity_WrapsCustomSourceError(t *testing.T) {
 
 func TestWorkloadIdentity_PassesThroughTypedSourceError(t *testing.T) {
 	sourceErr := &WorkloadIdentityRuntimeError{Source: "file", Message: "token file is empty: /var/run/token"}
-	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+	cred, err := NewWorkloadIdentity(IdentityTokenFunc(func(_ context.Context) (string, error) {
 		return "", sourceErr
 	}))
 	if err != nil {
@@ -124,7 +124,7 @@ func TestWorkloadIdentity_PassesThroughTypedSourceError(t *testing.T) {
 }
 
 func TestWorkloadIdentity_RejectsEmptyTokenFromSource(t *testing.T) {
-	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+	cred, err := NewWorkloadIdentity(IdentityTokenFunc(func(_ context.Context) (string, error) {
 		return "   \n", nil
 	}))
 	if err != nil {
@@ -149,7 +149,7 @@ func TestNewFileTokenSource_ExplicitPath(t *testing.T) {
 		t.Fatalf("constructing source: %v", err)
 	}
 
-	token, err := source.SubjectToken(context.Background())
+	token, err := source.IdentityToken(context.Background())
 	if err != nil {
 		t.Fatalf("fetching token: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestNewFileTokenSource_EnvDiscovery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("constructing source with %s set: %v", envVar, err)
 			}
-			token, err := source.SubjectToken(context.Background())
+			token, err := source.IdentityToken(context.Background())
 			if err != nil {
 				t.Fatalf("fetching token: %v", err)
 			}
@@ -225,7 +225,7 @@ func TestNewFileTokenSource_CustomEnvVarWins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("constructing source: %v", err)
 	}
-	token, err := source.SubjectToken(context.Background())
+	token, err := source.IdentityToken(context.Background())
 	if err != nil {
 		t.Fatalf("fetching token: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestGCPMetadataTokenSource_RequestShape(t *testing.T) {
 		t.Fatalf("constructing source: %v", err)
 	}
 
-	token, err := source.SubjectToken(context.Background())
+	token, err := source.IdentityToken(context.Background())
 	if err != nil {
 		t.Fatalf("fetching token: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestGCPMetadataTokenSource_RuntimeErrorOnFailure(t *testing.T) {
 				t.Fatalf("constructing source: %v", err)
 			}
 
-			_, err = source.SubjectToken(context.Background())
+			_, err = source.IdentityToken(context.Background())
 			var runtimeErr *WorkloadIdentityRuntimeError
 			if !errors.As(err, &runtimeErr) {
 				t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
@@ -362,7 +362,7 @@ func TestGCPMetadataTokenSource_RuntimeErrorWhenUnreachable(t *testing.T) {
 		t.Fatalf("constructing source: %v", err)
 	}
 
-	_, err = source.SubjectToken(context.Background())
+	_, err = source.IdentityToken(context.Background())
 	var runtimeErr *WorkloadIdentityRuntimeError
 	if !errors.As(err, &runtimeErr) {
 		t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
@@ -373,7 +373,7 @@ func TestGCPMetadataTokenSource_RuntimeErrorWhenUnreachable(t *testing.T) {
 }
 
 func TestNewWorkloadIdentity_RejectsNilFunc(t *testing.T) {
-	cred, err := NewWorkloadIdentity(SubjectTokenFunc(nil))
+	cred, err := NewWorkloadIdentity(IdentityTokenFunc(nil))
 
 	var cfgErr *WorkloadIdentityConfigurationError
 	if !errors.As(err, &cfgErr) {
@@ -435,7 +435,7 @@ func TestFlyTokenSource_RequestShape(t *testing.T) {
 		WithFlySocketPath(socketPath),
 	)
 
-	token, err := source.SubjectToken(context.Background())
+	token, err := source.IdentityToken(context.Background())
 	if err != nil {
 		t.Fatalf("fetching token: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestFlyTokenSource_EmptyObjectBodyWithoutAudience(t *testing.T) {
 
 	source := NewFlyTokenSource(WithFlySocketPath(socketPath))
 
-	if _, err := source.SubjectToken(context.Background()); err != nil {
+	if _, err := source.IdentityToken(context.Background()); err != nil {
 		t.Fatalf("fetching token: %v", err)
 	}
 }
@@ -470,7 +470,7 @@ func TestFlyTokenSource_RuntimeErrorOnFailure(t *testing.T) {
 		}))
 		source := NewFlyTokenSource(WithFlySocketPath(socketPath))
 
-		_, err := source.SubjectToken(context.Background())
+		_, err := source.IdentityToken(context.Background())
 		var runtimeErr *WorkloadIdentityRuntimeError
 		if !errors.As(err, &runtimeErr) {
 			t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
@@ -483,7 +483,7 @@ func TestFlyTokenSource_RuntimeErrorOnFailure(t *testing.T) {
 	t.Run("socket missing", func(t *testing.T) {
 		source := NewFlyTokenSource(WithFlySocketPath(filepath.Join(t.TempDir(), "no-such.sock")))
 
-		_, err := source.SubjectToken(context.Background())
+		_, err := source.IdentityToken(context.Background())
 		var runtimeErr *WorkloadIdentityRuntimeError
 		if !errors.As(err, &runtimeErr) {
 			t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
@@ -495,7 +495,7 @@ func TestFlyTokenSource_RuntimeErrorOnFailure(t *testing.T) {
 }
 
 func TestWorkloadIdentity_ClientID(t *testing.T) {
-	source := SubjectTokenFunc(func(_ context.Context) (string, error) { return "platform-token", nil })
+	source := IdentityTokenFunc(func(_ context.Context) (string, error) { return "platform-token", nil })
 
 	t.Run("set", func(t *testing.T) {
 		cred, err := NewWorkloadIdentity(source, WithWorkloadClientID("acr_123"))

--- a/mcp/workload_identity_test.go
+++ b/mcp/workload_identity_test.go
@@ -1,0 +1,371 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewWorkloadIdentity_RejectsNilSource(t *testing.T) {
+	cred, err := NewWorkloadIdentity(nil)
+
+	var cfgErr *WorkloadIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityConfigurationError", err)
+	}
+	if cred != nil {
+		t.Errorf("credential: got %v, want nil on error", cred)
+	}
+}
+
+func TestWorkloadIdentity_PreparesRequestFromSource(t *testing.T) {
+	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+		return "platform-token", nil
+	}))
+	if err != nil {
+		t.Fatalf("constructing credential: %v", err)
+	}
+
+	if auth := cred.Auth("https://zone.example.com"); auth != nil {
+		t.Errorf("Auth: got %v, want nil (assertion-based auth)", auth)
+	}
+
+	req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+	if err != nil {
+		t.Fatalf("preparing request: %v", err)
+	}
+	if req.ClientAssertion != "platform-token" {
+		t.Errorf("client assertion: got %q, want source token", req.ClientAssertion)
+	}
+	if req.ClientAssertionType != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("client assertion type: got %q", req.ClientAssertionType)
+	}
+	if req.SubjectToken != "subject-token" {
+		t.Errorf("subject token: got %q", req.SubjectToken)
+	}
+	if req.SubjectTokenType != "urn:ietf:params:oauth:token-type:access_token" {
+		t.Errorf("subject token type: got %q", req.SubjectTokenType)
+	}
+	if req.Resource != "https://resource.example.com" {
+		t.Errorf("resource: got %q", req.Resource)
+	}
+}
+
+func TestWorkloadIdentity_FetchesFreshTokenEveryExchange(t *testing.T) {
+	calls := 0
+	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+		calls++
+		return fmt.Sprintf("token-%d", calls), nil
+	}))
+	if err != nil {
+		t.Fatalf("constructing credential: %v", err)
+	}
+
+	for want := 1; want <= 2; want++ {
+		req, err := cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+		if err != nil {
+			t.Fatalf("preparing request %d: %v", want, err)
+		}
+		if req.ClientAssertion != fmt.Sprintf("token-%d", want) {
+			t.Errorf("exchange %d: client assertion %q, want fresh token (the credential must not cache)", want, req.ClientAssertion)
+		}
+	}
+	if calls != 2 {
+		t.Errorf("source calls: got %d, want one per exchange", calls)
+	}
+}
+
+func TestWorkloadIdentity_WrapsCustomSourceError(t *testing.T) {
+	cause := errors.New("socket unavailable")
+	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+		return "", cause
+	}))
+	if err != nil {
+		t.Fatalf("constructing credential: %v", err)
+	}
+
+	_, err = cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+	var runtimeErr *WorkloadIdentityRuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+	}
+	if runtimeErr.Source != "custom" {
+		t.Errorf("source: got %q, want %q", runtimeErr.Source, "custom")
+	}
+	if !errors.Is(err, cause) {
+		t.Errorf("errors.Is(cause): cause was dropped, got %v", err)
+	}
+}
+
+func TestWorkloadIdentity_PassesThroughTypedSourceError(t *testing.T) {
+	sourceErr := &WorkloadIdentityRuntimeError{Source: "file", Message: "token file is empty: /var/run/token"}
+	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+		return "", sourceErr
+	}))
+	if err != nil {
+		t.Fatalf("constructing credential: %v", err)
+	}
+
+	_, err = cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+	var runtimeErr *WorkloadIdentityRuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+	}
+	if runtimeErr.Source != "file" {
+		t.Errorf("source: got %q, want the source's own identifier preserved", runtimeErr.Source)
+	}
+}
+
+func TestWorkloadIdentity_RejectsEmptyTokenFromSource(t *testing.T) {
+	cred, err := NewWorkloadIdentity(SubjectTokenFunc(func(_ context.Context) (string, error) {
+		return "   \n", nil
+	}))
+	if err != nil {
+		t.Fatalf("constructing credential: %v", err)
+	}
+
+	_, err = cred.PrepareTokenExchangeRequest(context.Background(), "subject-token", "https://resource.example.com", nil)
+	var runtimeErr *WorkloadIdentityRuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+	}
+}
+
+func TestNewFileTokenSource_ExplicitPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte("projected-token\n"), 0o600); err != nil {
+		t.Fatalf("writing token file: %v", err)
+	}
+
+	source, err := NewFileTokenSource(WithFileTokenPath(path))
+	if err != nil {
+		t.Fatalf("constructing source: %v", err)
+	}
+
+	token, err := source.SubjectToken(context.Background())
+	if err != nil {
+		t.Fatalf("fetching token: %v", err)
+	}
+	if token != "projected-token" {
+		t.Errorf("token: got %q, want trimmed file contents", token)
+	}
+}
+
+func TestNewFileTokenSource_ConfigErrorOnMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	_, err := NewFileTokenSource(WithFileTokenPath(missing))
+
+	var cfgErr *WorkloadIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityConfigurationError", err)
+	}
+	if cfgErr.Source != "file" {
+		t.Errorf("source: got %q, want %q", cfgErr.Source, "file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("errors.Is(os.ErrNotExist): cause was dropped, got %v", err)
+	}
+}
+
+func TestNewFileTokenSource_EnvDiscovery(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte("discovered-token"), 0o600); err != nil {
+		t.Fatalf("writing token file: %v", err)
+	}
+
+	discoveryVars := append([]string{"CUSTOM_TOKEN_FILE"}, defaultFileTokenEnvVars...)
+	for _, envVar := range discoveryVars {
+		t.Run(envVar, func(t *testing.T) {
+			for _, v := range discoveryVars {
+				t.Setenv(v, "")
+			}
+			t.Setenv(envVar, path)
+
+			var opts []FileTokenSourceOption
+			if envVar == "CUSTOM_TOKEN_FILE" {
+				opts = append(opts, WithFileEnvVar(envVar))
+			}
+			source, err := NewFileTokenSource(opts...)
+			if err != nil {
+				t.Fatalf("constructing source with %s set: %v", envVar, err)
+			}
+			token, err := source.SubjectToken(context.Background())
+			if err != nil {
+				t.Fatalf("fetching token: %v", err)
+			}
+			if token != "discovered-token" {
+				t.Errorf("token: got %q, want token from discovered path", token)
+			}
+		})
+	}
+}
+
+func TestNewFileTokenSource_CustomEnvVarWins(t *testing.T) {
+	dir := t.TempDir()
+	customPath := filepath.Join(dir, "custom")
+	defaultPath := filepath.Join(dir, "default")
+	for path, contents := range map[string]string{customPath: "custom-token", defaultPath: "default-token"} {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("writing token file: %v", err)
+		}
+	}
+
+	t.Setenv("CUSTOM_TOKEN_FILE", customPath)
+	t.Setenv("KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE", defaultPath)
+
+	source, err := NewFileTokenSource(WithFileEnvVar("CUSTOM_TOKEN_FILE"))
+	if err != nil {
+		t.Fatalf("constructing source: %v", err)
+	}
+	token, err := source.SubjectToken(context.Background())
+	if err != nil {
+		t.Fatalf("fetching token: %v", err)
+	}
+	if token != "custom-token" {
+		t.Errorf("token: got %q, want the custom env var consulted first", token)
+	}
+}
+
+func TestNewFileTokenSource_ConfigErrorWithoutPathOrEnv(t *testing.T) {
+	for _, envVar := range defaultFileTokenEnvVars {
+		t.Setenv(envVar, "")
+	}
+
+	_, err := NewFileTokenSource()
+
+	var cfgErr *WorkloadIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityConfigurationError", err)
+	}
+}
+
+func TestNewEKSWorkloadIdentity_DoesNotDiscoverAzureVar(t *testing.T) {
+	// The deprecated EKS constructor keeps the EKS-only discovery list; the
+	// AKS variable is discovered only by NewFileTokenSource.
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte("azure-token"), 0o600); err != nil {
+		t.Fatalf("writing token file: %v", err)
+	}
+	for _, envVar := range defaultFileTokenEnvVars {
+		t.Setenv(envVar, "")
+	}
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", path)
+
+	if _, err := NewEKSWorkloadIdentity(); err == nil {
+		t.Error("NewEKSWorkloadIdentity: got nil error, want configuration error (EKS discovery must not include AZURE_FEDERATED_TOKEN_FILE)")
+	}
+
+	if _, err := NewFileTokenSource(); err != nil {
+		t.Errorf("NewFileTokenSource: got %v, want AZURE_FEDERATED_TOKEN_FILE discovered", err)
+	}
+}
+
+func TestGCPMetadataTokenSource_RequiresAudience(t *testing.T) {
+	_, err := NewGCPMetadataTokenSource("  ")
+
+	var cfgErr *WorkloadIdentityConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityConfigurationError", err)
+	}
+	if cfgErr.Source != "gcp-metadata" {
+		t.Errorf("source: got %q, want %q", cfgErr.Source, "gcp-metadata")
+	}
+}
+
+func TestGCPMetadataTokenSource_RequestShape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/computeMetadata/v1/instance/service-accounts/default/identity" {
+			t.Errorf("path: got %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("audience"); got != "https://zone.example.com" {
+			t.Errorf("audience: got %q", got)
+		}
+		if got := r.URL.Query().Get("format"); got != "full" {
+			t.Errorf("format: got %q, want full", got)
+		}
+		if got := r.Header.Get("Metadata-Flavor"); got != "Google" {
+			t.Errorf("Metadata-Flavor header: got %q, want Google", got)
+		}
+		_, _ = w.Write([]byte("gcp-identity-token\n"))
+	}))
+	defer server.Close()
+
+	source, err := NewGCPMetadataTokenSource("https://zone.example.com", WithGCPMetadataURL(server.URL))
+	if err != nil {
+		t.Fatalf("constructing source: %v", err)
+	}
+
+	token, err := source.SubjectToken(context.Background())
+	if err != nil {
+		t.Fatalf("fetching token: %v", err)
+	}
+	if token != "gcp-identity-token" {
+		t.Errorf("token: got %q, want trimmed response body", token)
+	}
+}
+
+func TestGCPMetadataTokenSource_RuntimeErrorOnFailure(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "non-200 status",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "not found", http.StatusNotFound)
+			},
+		},
+		{
+			name: "empty body",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("  \n"))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			source, err := NewGCPMetadataTokenSource("https://zone.example.com", WithGCPMetadataURL(server.URL))
+			if err != nil {
+				t.Fatalf("constructing source: %v", err)
+			}
+
+			_, err = source.SubjectToken(context.Background())
+			var runtimeErr *WorkloadIdentityRuntimeError
+			if !errors.As(err, &runtimeErr) {
+				t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+			}
+			if runtimeErr.Source != "gcp-metadata" {
+				t.Errorf("source: got %q, want %q", runtimeErr.Source, "gcp-metadata")
+			}
+		})
+	}
+}
+
+func TestGCPMetadataTokenSource_RuntimeErrorWhenUnreachable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	server.Close() // shut down immediately so the address refuses connections
+
+	source, err := NewGCPMetadataTokenSource("https://zone.example.com", WithGCPMetadataURL(server.URL))
+	if err != nil {
+		t.Fatalf("constructing source: %v", err)
+	}
+
+	_, err = source.SubjectToken(context.Background())
+	var runtimeErr *WorkloadIdentityRuntimeError
+	if !errors.As(err, &runtimeErr) {
+		t.Fatalf("error: got %v, want WorkloadIdentityRuntimeError", err)
+	}
+	if runtimeErr.Err == nil {
+		t.Error("Err: got nil, want the underlying transport error preserved")
+	}
+}

--- a/oauth/token_exchange.go
+++ b/oauth/token_exchange.go
@@ -23,6 +23,11 @@ type TokenExchangeRequest struct {
 	ActorTokenType      string
 	ClientAssertion     string
 	ClientAssertionType string
+	// ClientID names the application credential the client authenticates as,
+	// sent as the client_id form parameter. Used with assertion-based
+	// credentials that are resolved by ID rather than by the assertion's
+	// subject.
+	ClientID string
 }
 
 // TokenResponse represents an OAuth token endpoint response.
@@ -186,6 +191,9 @@ func serializeTokenExchangeRequest(req TokenExchangeRequest) url.Values {
 	}
 	if req.ClientAssertionType != "" {
 		params.Set("client_assertion_type", req.ClientAssertionType)
+	}
+	if req.ClientID != "" {
+		params.Set("client_id", req.ClientID)
 	}
 
 	return params


### PR DESCRIPTION
## What

Implements the [workload-identity spec](https://github.com/keycardai/keycard-sdk-spec/blob/main/specs/application-credentials/workload-identity.md) (status: Proposed, accepted in keycard-sdk-spec#39). Tracks [ECO-109](https://linear.app/keycardlabs/issue/ECO-109/credentials-go-workloadidentity-credential-subjecttokensource-workload).

One generic `WorkloadIdentityCredential` owns the invariant exchange contract: jwt-bearer client assertion, no Basic auth, fresh fetch on every exchange, no caching. The only per-platform code is a one-method interface:

```go
type SubjectTokenSource interface {
    SubjectToken(ctx context.Context) (string, error)
}
```

**Built-in sources (named by mechanism, not platform), the spec's complete v1 set:**
- `FileTokenSource`: projected token files. Covers EKS, AKS (`AZURE_FEDERATED_TOKEN_FILE` is in the default discovery list), and any Kubernetes projected service-account token.
- `GCPMetadataTokenSource`: GCP metadata identity endpoint (`?audience=&format=full` + `Metadata-Flavor: Google`). Covers GKE, GCE, Cloud Run.
- `FlyTokenSource`: POST `/v1/tokens/oidc` over the `/.fly/api` Unix socket, audience in the JSON body. Replaces the closed standalone-credential PR #8.
- `SubjectTokenFunc`: bare-function adapter for anything custom.

**Back-compat:** `NewEKSWorkloadIdentity`, its option types, and the EKS error types are now deprecated aliases with unchanged signatures. EKS keeps its EKS-only env discovery list (a test pins that it does NOT discover the Azure variable). All pre-existing EKS tests pass unchanged.

**Errors:** `WorkloadIdentity{Configuration,Runtime}Error` with exported `WorkloadIdentitySource*` constants for branching on the `Source` field, plus `Err` + `Unwrap()` so `errors.Is/As` reach the cause (ties to ECO-32).

**Package note:** lands in `mcp` alongside the other credentials; the move to the `oauth` package (matching `keycardai-oauth` / `@keycardai/oauth`) is the Go restructure, tracked separately.

## Adversarial review (applied)

- README credential table and feature list document `WorkloadIdentity` and mark `EKSWorkloadIdentity` deprecated
- `WithGCPHTTPClient` dropped: unspecced surface (the spec's GCP options are audience, metadata_url, timeout)
- Source identifier constants exported (`WorkloadIdentitySourceFile` etc.) so consumers don't branch on magic strings
- `errors.go` doc for `"custom"` tightened to "a source whose error is not one of this package's typed errors"
- `NewWorkloadIdentity(SubjectTokenFunc(nil))` is a construction-time configuration error instead of a first-exchange panic

## Testing

Conformance tests per the spec's Testing table (all 10 rows, including the Fly row): fake sources asserting the exact exchange-request shape and no-caching behavior, temp files + `t.Setenv` for every discovery variable, `httptest` for the GCP metadata request shape, and a real Unix-socket server for Fly (method, path, JSON body with/without audience, non-200, missing socket). `go vet`, `go test -race ./...`, and example builds are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)