### PR TITLE
fix: mark v0.14.0 as retracted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	golang.org/x/sync v0.11.0
 )
+
+retract v0.14.0 // reverted: unfinished policy bundle package


### PR DESCRIPTION
## Summary

- Adds a `retract v0.14.0` directive to `go.mod`
- `v0.14.0` was published but then reverted in #32 because the policy bundle package was unfinished and removed
- This retraction warns `go get` users that the version should not be used

## Test plan

- [ ] Verify `go mod tidy` passes with the retract directive in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)