### PR TITLE
fix(mcp): example audience binding, CI matrix refresh, x/sync bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23', '1.25']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/examples/hello-world-server/main.go
+++ b/examples/hello-world-server/main.go
@@ -36,6 +36,11 @@ func main() {
 	// WithAudiences binds accepted tokens to this resource server; without it,
 	// a token the zone minted for any other resource server would also pass
 	// the scope and expiry checks here.
+	// SERVER_URL must match the scheme and host clients actually reach: the
+	// metadata handler advertises the request-derived origin as the resource,
+	// and a token minted for that advertised origin fails this audience check
+	// if SERVER_URL differs. Behind a TLS-terminating proxy, forward
+	// X-Forwarded-Proto or the advertised scheme downgrades to http.
 	verifier, err := mcp.NewZoneTokenVerifier(zoneURL, oauth.WithAudiences(serverURL))
 	if err != nil {
 		log.Fatal(err)

--- a/examples/hello-world-server/main.go
+++ b/examples/hello-world-server/main.go
@@ -8,12 +8,18 @@ import (
 	"os"
 
 	"github.com/keycardai/go-sdk/mcp"
+	"github.com/keycardai/go-sdk/oauth"
 )
 
 func main() {
 	zoneURL := os.Getenv("KEYCARD_ZONE_URL")
 	if zoneURL == "" {
 		log.Fatal("KEYCARD_ZONE_URL environment variable is required")
+	}
+
+	serverURL := os.Getenv("SERVER_URL")
+	if serverURL == "" {
+		serverURL = "http://localhost:8080"
 	}
 
 	mux := http.NewServeMux()
@@ -27,7 +33,10 @@ func main() {
 
 	// The verifier trusts only tokens issued by this zone and resolves keys from its
 	// JWKS. It rejects tokens from any other issuer before resolving a key.
-	verifier, err := mcp.NewZoneTokenVerifier(zoneURL)
+	// WithAudiences binds accepted tokens to this resource server; without it,
+	// a token the zone minted for any other resource server would also pass
+	// the scope and expiry checks here.
+	verifier, err := mcp.NewZoneTokenVerifier(zoneURL, oauth.WithAudiences(serverURL))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cedar-policy/cedar-go v1.5.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gowebpki/jcs v1.0.1
-	golang.org/x/sync v0.11.0
+	golang.org/x/sync v0.16.0
 )
 
 require golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e h1:Ctm9yurWsg7aWwIpH9Bnap/IdSVxixymIb3MhiMEQQA=
 golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
The three PR-sized items from the ECO-131 net/http eval (full scorecard on the ticket).

- **hello-world-server audience binding**: the front-door example built its verifier without `oauth.WithAudiences`, so a copy-paste deployment accepted any token the zone minted for any resource server as long as scopes matched. Same fix the MCP examples got in #36; the example now binds to `SERVER_URL` (default `http://localhost:8080`) with a comment explaining what omitting it accepts.
- **CI matrix**: the `['1.22', '1.23']` matrix tested 1.23 twice (the 1.22 leg auto-upgrades via GOTOOLCHAIN to satisfy the go.mod 1.23.0 directive) and both are EOL. Now `['1.23', '1.25']`: the declared floor plus current stable.
- **x/sync bump**: v0.11.0 (Feb 2025) to v0.16.0, the newest release that keeps the `go 1.23` directive. v0.17.0+ requires go 1.24+, so going further means raising the module's Go floor for all consumers; flagged as a separate decision rather than smuggled into a hygiene PR (an `@latest` bump silently rewrites the directive to 1.25.0).

Root module: build, vet, `go test -race` all green; go 1.23 floor unchanged.

Spec-level follow-ups from the same eval are filed separately: ECO-159 (make audience binding required in zone verifier construction, cross-SDK) and ECO-160 (pre-RFC-8707 shim mints `resource=origin`, conflicting with path-bound audiences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
